### PR TITLE
fix typo in about/rationale

### DIFF
--- a/i18n/po/content/about/rationale/ja.po
+++ b/i18n/po/content/about/rationale/ja.po
@@ -91,7 +91,7 @@ msgstr ""
 #. type: Plain text
 #: en/content/about/rationale.adoc:19
 msgid "Clojure has a distinctive approach to <<state#,state and identity>>."
-msgstr "Clocjureは <<state#,状態とアイデンティティ>> に対して独自のアプローチをとっている。"
+msgstr "Clojureは <<state#,状態とアイデンティティ>> に対して独自のアプローチをとっている。"
 
 #. type: Title ==
 #: en/content/about/rationale.adoc:20


### PR DESCRIPTION
[Rationaleのページ](https://japan-clojurians.github.io/clojure-site-ja/about/rationale.html)に1箇所typoを見つけたので修正しました。