### PR TITLE
Display GUIDES pages

### DIFF
--- a/i18n/po/content/about/dynamic/ja.po
+++ b/i18n/po/content/about/dynamic/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2017-04-03 00:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,31 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/protocols.adoc:36 en/content/reference/datatypes.adoc:21 en/content/about/dynamic.adoc:42

--- a/i18n/po/content/about/functional_programming/ja.po
+++ b/i18n/po/content/about/functional_programming/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2017-04-05 02:06+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,39 +17,23 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4 en/content/reference/metadata.adoc:4
-#: en/content/reference/evaluation.adoc:4 en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4 en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4 en/content/reference/other_libraries.adoc:4
-#: en/content/reference/data_structures.adoc:4 en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4 en/content/reference/lisps.adoc:4
-#: en/content/reference/lazy.adoc:4 en/content/reference/repl_and_main.adoc:4 en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/multimethods.adoc:4
-#: en/content/search.adoc:4 en/content/about/clojureclr.adoc:4 en/content/about/functional_programming.adoc:4
-#: en/content/about/lisp.adoc:4 en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4 en/content/about/rationale.adoc:4
-#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4 en/content/privacy.adoc:4
-#: en/content/community/swag.adoc:4 en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
-#: en/content/community/downloads_older.adoc:4 en/content/community/libraries.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4 en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/transients.adoc:4
+#: en/content/reference/compilation.adoc:4 en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4 en/content/reference/transducers.adoc:4
+#: en/content/reference/refs.adoc:4 en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4 en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4 en/content/reference/data_structures.adoc:4 en/content/reference/atoms.adoc:4
+#: en/content/reference/repl_and_main.adoc:4 en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4 en/content/community/downloads_older.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4 en/content/404.adoc:4
+#: en/content/privacy.adoc:4 en/content/search.adoc:4 en/content/about/spec.adoc:4
+#: en/content/about/concurrent_programming.adoc:4 en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4 en/content/about/features.adoc:4
+#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/special_forms.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/metadata.adoc:15 en/content/reference/reader.adoc:13 en/content/reference/transients.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_functions.adoc:17 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/java_interop.adoc:15 en/content/reference/data_structures.adoc:16
-#: en/content/reference/datatypes.adoc:16 en/content/reference/agents.adoc:16 en/content/reference/protocols.adoc:15
-#: en/content/reference/reducers.adoc:15 en/content/reference/lazy.adoc:12 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/transducers.adoc:15 en/content/reference/vars.adoc:16 en/content/reference/namespaces.adoc:15
-#: en/content/reference/libs.adoc:16 en/content/reference/multimethods.adoc:15
-#: en/content/about/functional_programming.adoc:15 en/content/about/dynamic.adoc:16 en/content/about/spec.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/about/functional_programming.adoc:1

--- a/i18n/po/content/about/rationale/ja.po
+++ b/i18n/po/content/about/rationale/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
-"PO-Revision-Date: 2018-05-04 05:20+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 00:52+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -35,28 +35,18 @@ msgstr ""
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
 
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
-
 #. type: Title =
-#: en/content/reference/transients.adoc:17 en/content/news/2013/06/28/clojure-clore-async-channels.adoc:10
-#: en/content/about/rationale.adoc:1
+#: en/content/reference/deps_and_cli.adoc:14 en/content/reference/transients.adoc:17
+#: en/content/news/2013/06/28/clojure-clore-async-channels.adoc:10 en/content/about/rationale.adoc:1
 #, no-wrap
 msgid "Rationale"
 msgstr "論理的根拠"
+
+#. type: Plain text
+#: en/content/guides/guides.adoc:29 en/content/about/rationale.adoc:68
+#, no-wrap
+msgid "Libraries"
+msgstr "ライブラリ"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:15
@@ -156,30 +146,59 @@ msgid "Core advantage still code-as-data and syntactic abstraction"
 msgstr "いまだ核心的な強みであるデータとしてのコード(code-as-data)とシンタックスの抽象化"
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:38
+msgid "What about the standard Lisps (Common Lisp and Scheme)?"
+msgstr "標準のLisp (Common LispとScheme)はどうだろうか?"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:39
+msgid "Slow/no innovation post standardization"
+msgstr "標準化以降のイノベーションが遅い/ない"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:40
+msgid "Core data structures mutable, not extensible"
+msgstr "コアとなるデータ構造がミュータブルで、拡張もできない"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:41
+msgid "No concurrency in specs"
+msgstr "並行処理が仕様に含まれていない"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:42
+msgid "Good implementations already exist for JVM (ABCL, Kawa, SISC et al)"
+msgstr "JVM向けの良い実装がすでに存在する(ABCL, Kawa, SISCなど)"
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:43
-msgid ""
-"What about the standard Lisps (Common Lisp and Scheme)? ** Slow/no innovation post standardization ** Core data "
-"structures mutable, not extensible ** No concurrency in specs ** Good implementations already exist for JVM (ABCL, "
-"Kawa, SISC et al)  ** Standard Lisps are their own platforms"
-msgstr ""
-"標準のLisp(Common LispとScheme)はどうだろう?\n"
-"** 標準化以降のイノベーションが遅い/ない\n"
-"** コアとなるデータ構造がミュータブルで、拡張もできない\n"
-"** 並行処理が仕様に含まれていない\n"
-"** JVM向けの良い実装がすでに存在する(ABCL, Kawa, SISCなど)\n"
-"** 標準のLispはそれぞれ固有のプラットフォームになっている"
+msgid "Standard Lisps are their own platforms"
+msgstr "標準のLispはそれぞれ固有のプラットフォームになっている"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:44
+msgid "Clojure is a Lisp not constrained by backwards compatibility"
+msgstr "Clojureは後方互換性による制約のないLispだ"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:45
+msgid "Extends the code-as-data paradigm to maps and vectors"
+msgstr "データとしてのコード(code-as-data)というパラダイムをマップとベクターにまで拡張している"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:46
+msgid "Defaults to immutability"
+msgstr "デフォルトでイミュータブルになっている"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:47
+msgid "Core data structures are extensible abstractions"
+msgstr "コアのデータ構造は拡張可能な抽象だ"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:48
-msgid ""
-"Clojure is a Lisp not constrained by backwards compatibility ** Extends the code-as-data paradigm to maps and vectors "
-"** Defaults to immutability ** Core data structures are extensible abstractions ** Embraces a platform (JVM)"
-msgstr ""
-"Clojureは後方互換性による制約のないLispだ\n"
-"** code-as-dataのパラダイムをマップとベクターに拡張している\n"
-"** デフォルトでイミュータブルになっている\n"
-"** コアとなるデータ構造は拡張可能な抽象だ\n"
-"** プラットフォーム(JVM)を受け入れている"
+msgid "Embraces a platform (JVM)"
+msgstr "プラットフォーム(JVM)を受け入れている"
 
 #. type: Title ==
 #: en/content/about/rationale.adoc:49
@@ -193,32 +212,49 @@ msgid "Immutable data + first-class functions"
 msgstr "イミュータブルなデータ + 第一級関数"
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:53
+msgid "Could always be done in Lisp, by discipline/convention"
+msgstr "Lispでは規律や規約によって常に可能だった"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:54
+msgid "But if a data structure _can_ be mutated, dangerous to presume it won't be"
+msgstr "しかしデータ構造が変更され _うる_ ものであれば変更されないと推定するのは危険だ"
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:55
-msgid ""
-"Could always be done in Lisp, by discipline/convention ** But if a data structure _can_ be mutated, dangerous to "
-"presume it won't be ** In traditional Lisp, only the list data structure is structurally recursive"
-msgstr ""
-"Lispでは規律や規約によって常に可能だった\n"
-"** しかしデータ構造が変更されうるものであれば変更されないと推定するのは危険だ\n"
-"** 伝統的なLispでは、リストというデータ構造だけが構造的に再帰的だ"
+msgid "In traditional Lisp, only the list data structure is structurally recursive"
+msgstr "伝統的なLispでは、リストというデータ構造だけが構造的に再帰的だ"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:56
+msgid "Pure functional languages tend to strongly static types"
+msgstr "純粋関数型言語は強い静的型付けである傾向にある"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:57
-msgid "Pure functional languages tend to strongly static types ** Not for everyone, or every task"
-msgstr ""
-"純粋関数型言語は強い静的型付けである傾向にある\n"
-"** みんなに適しているわけではないし、あらゆるタスクに適しているわけでもない"
+msgid "Not for everyone, or every task"
+msgstr "みんなに適しているわけではないし、あらゆるタスクに適しているわけでもない"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:58
+msgid "Clojure is a functional language with a dynamic emphasis"
+msgstr "Clojureは動的であることを重視する関数型言語だ"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:59
+msgid "All data structures immutable & persistent, supporting recursion"
+msgstr "すべてのデータ構造はイミュータブルで永続的で再帰をサポートしている"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:60
+msgid "Heterogeneous collections, return types"
+msgstr "異なる型の値が混在したコレクションや戻り型"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:61
-msgid ""
-"Clojure is a functional language with a dynamic emphasis ** All data structures immutable & persistent, supporting "
-"recursion ** Heterogeneous collections, return types ** Dynamic polymorphism"
-msgstr ""
-"Clojureは動的であることを重視する関数型言語だ\n"
-"** すべてのデータ構造はイミュータブルで永続的で再帰をサポートしている\n"
-"** 異なる型の値が混在したコレクションや戻り型\n"
-"** 動的ポリモーフィズム"
+msgid "Dynamic polymorphism"
+msgstr "動的ポリモーフィズム"
 
 #. type: Title ==
 #: en/content/about/rationale.adoc:62
@@ -227,76 +263,164 @@ msgid "Languages and Platforms"
 msgstr "言語とプラットフォーム"
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:65
+msgid "VMs, not OSes, are the platforms of the future, providing:"
+msgstr "OSではなくVMが未来のプラットフォームであり、次のものを提供する:"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:66
+msgid "Type system"
+msgstr "型システム"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:67
+msgid "Dynamic enforcement and safety"
+msgstr "動的な強制と安全性"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:69
+msgid "Abstract away OSes"
+msgstr "OSの抽象化"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:70
+msgid "_Huge_ set of facilities"
+msgstr "_非常に多数の_ 機能の集合"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:71
+msgid "Built-in and 3rd-party"
+msgstr "組み込みとサードパーティ"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:72
+msgid "Memory and other resource management"
+msgstr "メモリと他のリソースの管理"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:73
+msgid "GC is platform, not language, facility"
+msgstr "GCは言語ではなくプラットフォームの機能である"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:74
+msgid "Bytecode + JIT compilation"
+msgstr "バイトコード + JITコンパイル"
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:75
-msgid ""
-"VMs, not OSes, are the platforms of the future, providing: ** Type system *** Dynamic enforcement and safety ** "
-"Libraries *** Abstract away OSes *** _Huge_ set of facilities *** Built-in and 3rd-party ** Memory and other resource "
-"management *** GC is platform, not language, facility ** Bytecode + JIT compilation *** Abstracts away hardware"
-msgstr ""
-"OSではなくVMが未来のプラットフォームであり、次のものを提供する: \n"
-"** 型システム\n"
-"*** 動的な強制と安全性\n"
-"** ライブラリ\n"
-"*** OSの抽象化\n"
-"*** 非常に多数の機能の集合\n"
-"*** 組み込みとサードパーティ\n"
-"** メモリと他のリソースの管理\n"
-"*** GCは言語ではなくプラットフォームの機能である\n"
-"** バイトコード + JITコンパイル\n"
-"*** ハードウェアの抽象化"
+msgid "Abstracts away hardware"
+msgstr "ハードウェアの抽象化"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:76
+msgid "Language as platform vs. language + platform"
+msgstr "プラットフォームとしての言語 vs. 言語 + プラットフォーム"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:77
+msgid "Old way - each language defines its own runtime"
+msgstr "古いやり方 - 各言語がそれぞれランタイムを定義する"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:78
+msgid "GC, bytecode, type system, libraries etc"
+msgstr "GC、バイトコード、型システム、ライブラリなど"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:79
+msgid "New way (JVM, .Net)"
+msgstr "新しいやり方(JVM, .NET)"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:80
-msgid ""
-"Language as platform vs. language + platform ** Old way - each language defines its own runtime *** GC, bytecode, "
-"type system, libraries etc ** New way (JVM, .Net)  *** Common runtime independent of language"
-msgstr ""
-"プラットフォームとしての言語 vs. 言語 + プラットフォーム\n"
-"** 古いやり方 - 各言語がそれぞれランタイムを定義する\n"
-"*** GC、バイトコード、型システム、ライブラリなど\n"
-"** 新しいやり方(JVM, .NET)\n"
-"*** 言語とは独立した共通のランタイム"
+msgid "Common runtime independent of language"
+msgstr "言語とは独立した共通のランタイム"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:81
+msgid "Language built for platform vs language ported-to platform"
+msgstr "プラットフォームのために構築された言語 vs プラットフォームにポートされた言語"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:82
+msgid "Many new languages still take 'Language as platform' approach"
+msgstr "多くの新しい言語はいまだ「プラットフォームとしての言語」というアプローチをとっている"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:83
+msgid "When ported, have platform-on-platform issues"
+msgstr "ポートされる際にプラットフォーム上のプラットフォームという問題を抱えることになる"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:84
+msgid "Memory management, type-system, threading issues"
+msgstr "メモリ管理、型システム、スレッドの問題"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:85
+msgid "Library duplication"
+msgstr "ライブラリの重複"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:86
-msgid ""
-"Language built for platform vs language ported-to platform ** Many new languages still take 'Language as platform' "
-"approach ** When ported, have platform-on-platform issues *** Memory management, type-system, threading issues *** "
-"Library duplication *** If original language based on C, some extension libraries written in C don't come over"
-msgstr ""
-"プラットフォームのために構築された言語 vs プラットフォームにポートされた言語\n"
-"** 多くの新しい言語はいまだ「プラットフォームとしての言語」というアプローチをとっている\n"
-"** ポートされる際にプラットフォーム上のプラットフォームという問題を抱えることになる\n"
-"*** メモリ管理、型システム、スレッドの問題\n"
-"*** ライブラリの重複\n"
-"*** 元の言語がC言語をベースにしていても、C言語で書かれた一部の拡張ライブラリはついてこない"
+msgid "If original language based on C, some extension libraries written in C don't come over"
+msgstr "元の言語がC言語をベースにしていても、C言語で書かれた一部の拡張ライブラリはついてこない"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:87
+msgid "Platforms are dictated by clients"
+msgstr "プラットフォームは顧客に指定されている"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:88
+msgid "'Must run on JVM' or .Net vs 'must run on Unix' or Windows"
+msgstr "「JVM(または.NET)上で実行しなければならない」vs「UNIX(またはWindows)で実行しなければならない」"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:89
+msgid "JVM has established track record and trust level"
+msgstr "JVMは実績と信頼できるレベルを確立してきた"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:90
+msgid "Now also open source"
+msgstr "今やオープンソースでもある"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:91
+msgid "Interop with other code required"
+msgstr "他のコードとの相互運用が求められる"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:92
-msgid ""
-"Platforms are dictated by clients ** 'Must run on JVM' or .Net vs 'must run on Unix' or Windows ** JVM has "
-"established track record and trust level *** Now also open source ** Interop with other code required *** C linkage "
-"insufficient these days"
-msgstr ""
-"プラットフォームは顧客に指定されている\n"
-"** 「JVM(または.NET)上で実行しなければならない」vs「UNIX(またはWindows)で実行しなければならない」\n"
-"** JVMは実績と信頼できるレベルを確立してきた\n"
-"*** 今やオープンソースでもある\n"
-"** 他のコードとの相互運用が求められる\n"
-"*** C言語との連携では最近では不十分になってきている"
+msgid "C linkage insufficient these days"
+msgstr "C言語との連携では最近では不十分になってきている"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:93
+msgid "Java/JVM _is_language + platform"
+msgstr "Java/JVMは言語 + プラットフォーム"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:94
+msgid "Not the original story, but other languages for JVM always existed, now embraced by Sun"
+msgstr "もともとそうだったわけではないが、JVM向けの他の言語は常に存在し、今やSunにも受け入れられている"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:95
+msgid "Java can be tedious, insufficiently expressive"
+msgstr "Javaは冗長で表現力が不十分になりがちだ"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:96
+msgid "Lack of first-class functions, no type inference, etc"
+msgstr "第一級関数を欠き、型推論がない、など"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:97
-msgid ""
-"Java/JVM _is_language + platform ** Not the original story, but other languages for JVM always existed, now embraced "
-"by Sun ** Java can be tedious, insufficiently expressive *** Lack of first-class functions, no type inference, etc ** "
-"Ability to call/consume Java is critical"
-msgstr ""
-"Java/JVMは言語 + プラットフォーム\n"
-"** もともとそうだったわけではないが、JVM向けの他の言語は常に存在し、今やSunにも受け入れられている\n"
-"** Javaは冗長で表現力が不十分になりがちだ\n"
-"*** 第一級関数を欠き、型推論がない、など\n"
-"** Javaを呼び出し取り込む能力は決定的に重要だ"
+msgid "Ability to call/consume Java is critical"
+msgstr "Javaを呼び出し取り込む能力は決定的に重要だ"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:98
@@ -310,22 +434,29 @@ msgid "Object Orientation is overrated"
 msgstr "オブジェクト指向は過大評価されている"
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:102
+msgid "Born of simulation, now used for everything, even when inappropriate"
+msgstr "シミュレーションから生まれ、今ではあらゆるものに、時には適していないものにさえ利用されている"
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:103
-msgid ""
-"Born of simulation, now used for everything, even when inappropriate ** Encouraged by Java/C# in all situations, due "
-"to their lack of (idiomatic) support for anything else"
-msgstr ""
-"シミュレーションから生まれ、今ではあらゆるものに、時には適していないものにさえ利用されている\n"
-"** Java/C#によってあらゆる状況で奨励されてきたが、それはJava/C#がそれ以外の(慣用的な)方法を欠いていたためだ"
+msgid "Encouraged by Java/C# in all situations, due to their lack of (idiomatic) support for anything else"
+msgstr "Java/C#によってあらゆる状況で奨励されてきたが、それはJava/C#がそれ以外の(慣用的な)方法を欠いていたためだ"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:104
+msgid "Mutable stateful objects are the new spaghetti code"
+msgstr "ミュータブルでステートフルなオブジェクトは新たなスパゲッティコードだ"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:105
+msgid "Hard to understand, test, reason about"
+msgstr "理解するのもテストするのも推論するのも難しい"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:106
-msgid ""
-"Mutable stateful objects are the new spaghetti code ** Hard to understand, test, reason about ** Concurrency disaster"
-msgstr ""
-"ミュータブルでステートフルなオブジェクトは新たなスパゲッティコードだ\n"
-"** 理解するのもテストするのも推論するのも難しい\n"
-"** 並行処理にとって災難だ"
+msgid "Concurrency disaster"
+msgstr "並行処理にとって災難だ"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:107
@@ -377,14 +508,19 @@ msgid "Polymorphism yields extensible, flexible systems"
 msgstr "ポリモーフィズムは拡張可能で柔軟なシステムをもたらす"
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:117
+msgid "Clojure multimethods decouple polymorphism from OO and types"
+msgstr "Clojureのマルチメソッドはオブジェクト指向と型からポリモーフィズムを分離したものだ"
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:118
+msgid "Supports multiple taxonomies"
+msgstr "複数の基準での分類をサポートしている"
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:119
-msgid ""
-"Clojure multimethods decouple polymorphism from OO and types ** Supports multiple taxonomies ** Dispatches via "
-"static, dynamic or external properties, metadata, etc"
-msgstr ""
-"Clojureのマルチメソッドはオブジェクト指向と型からポリモーフィズムを分離したものだ\n"
-"** 複数の基準での分類をサポートしている\n"
-"** 静的、動的または外部的なプロパティ、メタデータなどによってディスパッチする"
+msgid "Dispatches via static, dynamic or external properties, metadata, etc"
+msgstr "静的、動的または外部的なプロパティ、メタデータなどによってディスパッチする"
 
 #. type: Title ==
 #: en/content/about/rationale.adoc:120
@@ -393,11 +529,14 @@ msgid "Concurrency and the multi-core future"
 msgstr "並行処理とマルチコアの未来"
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:123
+msgid "Immutability makes much of the problem go away"
+msgstr "イミュータブルであることによって多くの問題はなくなる"
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:124
-msgid "Immutability makes much of the problem go away ** Share freely between threads"
-msgstr ""
-"イミュータブルであることによって多くの問題はなくなる\n"
-"** スレッド間で自由に共有できる"
+msgid "Share freely between threads"
+msgstr "スレッド間で自由に共有できる"
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:125

--- a/i18n/po/content/about/spec/ja.po
+++ b/i18n/po/content/about/spec/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2019-02-18 20:10+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,27 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ====
 #: en/content/reference/sequences.adoc:1 en/content/guides/spec.adoc:513 en/content/about/spec.adoc:234

--- a/i18n/po/content/about/state/ja.po
+++ b/i18n/po/content/about/state/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-15 14:02+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,23 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/transients.adoc:75 en/content/guides/comparators.adoc:12 en/content/about/state.adoc:74

--- a/i18n/po/content/community/books/ja.po
+++ b/i18n/po/content/community/books/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -37,240 +37,169 @@ msgstr ""
 msgid "_Listed in order of descending release date of newest edition._"
 msgstr ""
 
-#. type: Plain text
-#: en/content/community/books.adoc:14 en/content/community/books.adoc:175 en/content/community/companies.adoc:14
-#: en/content/community/companies.adoc:15
-msgid "|==="
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:19
+#. type: Table
+#: en/content/community/books.adoc:175
+#, no-wrap
 msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51Bvd25CstL._SL160.jpg[Programming Clojure 3rd edition,link=\"http://a."
-"co/bSxW6A6\"] | http://a.co/bSxW6A6[Programming Clojure 3rd edition] + by Alex Miller, Stuart Halloway, Aaron Bedra + "
-"Feb 21, 2018"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:24
-msgid ""
-"| image::https://s3.amazonaws.com/titlepages.leanpub.com/elementsofclojure/small[Elements of Clojure,link=\"https://"
-"leanpub.com/elementsofclojure\"] | https://leanpub.com/elementsofclojure[Elements of Clojure] + by Zachary Tellman + "
-"Sep 27, 2017"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:29
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/41k50H6VpaL._SL160.jpg[ClojureScript Unraveled,link=\"http://a.co/"
-"cDfN4n4\"] | http://a.co/cDfN4n4[Quick Clojure: Effective Functional Programming] + by Mark McDonnell + Aug 23, 2017"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:34
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/518xLvhHZ1L._SL160.jpg[Web Development with Clojure,link=\"http://a.co/"
-"c2gI4l2\"] | http://a.co/c2gI4l2[Web Development with Clojure] + by Dmitri Sotnikov + Aug 23, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:39
-msgid ""
-"| image::https://s3.amazonaws.com/titlepages.leanpub.com/clojurescript-unraveled/small[ClojureScript Unraveled,link="
-"\"https://leanpub.com/clojurescript-unraveled\"] | https://leanpub.com/clojurescript-unraveled[ClojureScript "
-"Unraveled] + by Andrey Antukh, Alejandro Gómez + Jul 25, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:44
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51EwRiXh4ZL._SL160.jpg[Learning ClojureScript, link=\"http://a."
-"co/2X3MJn2\"] | http://a.co/2X3MJn2[Learning ClojureScript] + by W. David Jarvis, Rafik Naccache, Allen Rohner + Jun "
-"30, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:49
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51iq-PKIZ8L._SL160.jpg[Professional Clojure, link=\"http://a.co/"
-"bSHZ7X3\"] | http://a.co/bSHZ7X3[Professional Clojure] + by Jeremy Anderson, Michael Gaare, Justin Holguín, Nick "
-"Bailey, and Timothy Pratley + Jun 7, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:54
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/61TJZjnjO0L._SL160.jpg[Mastering Clojure, link=\"http://a.co/bTLhJ2d"
-"\"] | http://a.co/bTLhJ2d[Mastering Clojure] + by Akhil Wali + Mar 28, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:59
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/61p47dd81cL._SL160.jpg[Clojure for Java Developers, link=\"http://a."
-"co/029aVrm\"] | http://a.co/029aVrm[Clojure for Java Developers] + by Eduardo Diaz + Feb 23, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:64
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51ofF2ckdkL._SL160.jpg[Clojure for Finance, link=\"http://a.co/fbHnhEM"
-"\"] | http://a.co/fbHnhEM[Clojure for Finance] + by Timothy Washington + Jan 11, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:69
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51QWOEjmtIL._SL160.jpg[Clojure In Action, link=\"http://a.co/a4hDbTn"
-"\"] | http://a.co/a4hDbTn[Clojure In Action] + by Amit Rathore + Jan 1, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:74
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/6112vbQYDLL._SL160.jpg[Clojure for the Brave and True,link=\"http://a."
-"co/bsviqV7\"] | http://a.co/bsviqV7[Clojure for the Brave and True] + by Daniel Higginbotham + Oct 23, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:79
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51aMgNS%2BK7L._SL160.jpg[Clojure Recipes,link=\"http://a.co/clSHVQi\"] "
-"| http://a.co/clSHVQi[Clojure Recipes] + by Julian Gamble + Oct 23, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:84
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/41iH5aTHB3L._SL160.jpg[Clojure Applied,link=\"http://a.co/1HL2XPF\"] | "
-"http://a.co/1HL2XPF[Clojure Applied: From Practice to Practitioner] + by Ben Vandgrift, Alex Miller + Sept 6, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:89
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51ki-47i6bL._SL160.jpg[Clojure for Data Science,link=\"http://a.co/"
-"idtKjhS\"] | http://a.co/idtKjhS[Clojure for Data Science] + by Henry Garner + Sept 3, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:94
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51Nym1wJXVL._SL160.jpg[Clojure High Performance Programming,link="
-"\"http://a.co/7adcmsl\"] | http://a.co/7adcmsl[Clojure High Performance Programming] + by Shantanu Kumar + Sept 1, "
-"2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:99
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/515vh5czqnL._SL160.jpg[Clojure Data Structures and Algorithms,link="
-"\"http://a.co/g7JAFAS\"] | http://a.co/g7JAFAS[Clojure Data Structures and Algorithms] + by Rafik Naccache + Aug 19, "
-"2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:104
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/5122uV93jfL._SL160.jpg[Living Clojure,link=\"http://a.co/1m2Zt4p\"] | "
-"http://a.co/1m2Zt4p[Living Clojure] + by Carin Meier + Apr 30, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:109
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51l1oGz9N7L._SL160.jpg[Clojure Reactive Programming,link=\"http://a.co/"
-"fhyaFka\"] | http://a.co/fhyaFka[Clojure Reactive Programming] + by Leonardo Borges + Mar 24, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:114
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51XnilmUaIL._SL160.jpg[Clojure Web Development Essentials,link="
-"\"http://a.co/2FlRxd5\"] | http://a.co/2FlRxd5[Clojure Web Development Essentials] + by Ryan Baldwin + Feb 16, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:119
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51-B3kElSiL._SL160.jpg[Clojure Data Analysis Cookbook, link=\"http://a."
-"co/gIwPEkt\"] | http://a.co/gIwPEkt[Clojure Data Analysis Cookbook] + by Eric Rochester + Jan 22, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:124
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51nhUEYSLhL._SL160.jpg[Mastering Clojure Macros,link=\"http://a."
-"co/4VjjiQJ\"] | http://a.co/4VjjiQJ[Mastering Clojure Macros] + by Colin Jones + Sept 5, 2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:129
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/518RxlXpXsL._SL160.jpg[The Joy of Clojure,link=\"http://a.co/evdNcOs"
-"\"] | http://a.co/evdNcOs[The Joy of Clojure] + by Michael Fogus, Chris Houser + Jun 13, 2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:134
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51gyxyvmX3L._SL160.jpg[Mastering Clojure Data Analysis,link=\"http://a."
-"co/bYwhMwH\"] | http://a.co/bYwhMwH[Mastering Clojure Data Analysis] + by Eric Rochester + May 26, 2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:139
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51Af%2B5qKOeL._SL160.jpg[Clojure for Machine Learning,link=\"http://a."
-"co/7PRmDOK\"] | http://a.co/7PRmDOK[Clojure for Machine Learning] + by Akhil Wali + Apr 24, 2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:144
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51NPZu-5PiL._SL160.jpg[Clojure Cookbook, link=\"http://a.co/1K6SZSI\"] "
-"| http://a.co/1K6SZSI[Clojure Cookbook] + by Luke VanderHart and Ryan Neufeld + Mar 24, 2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:149
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/515hwMhZELL._SL160.jpg[Clojure for Domain-specific Languages,link="
-"\"http://a.co/3rwXJkx\"] | http://a.co/3rwXJkx[Clojure for Domain-specific Languages] + by Ryan Kelker + Dec 18, 2013"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:154
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51i1Cn-IqdL._SL160.jpg[Functional Programming Patterns in Scala and "
-"Clojure,link=\"http://a.co/2J3jvLX\"] | http://a.co/2J3jvLX[Functional Programming Patterns in Scala and Clojure] + "
-"by Michael Bevilacqua-Linn + Nov 2, 2013"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:159
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51KgF%2B-38WL._SL160.jpg[ClojureScript: Up and Running,link=\"http://a."
-"co/74IUDUu\"] | http://a.co/74IUDUu[ClojureScript: Up and Running] + by Stuart Sierra, Luke VanderHart + Nov 10, 2012"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:164
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/41sY2b6MKiL._SL160.jpg[Clojure Programming,link=\"http://a.co/jiaX8tX"
-"\"] | http://a.co/jiaX8tX[Clojure Programming] + by Chas Emerick, Brian Carper, Christophe Grand + Apr 22, 2012"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:169
-msgid ""
-"| image::http://clojure-buch.de/cover.jpg[Clojure,link=\"http://clojure-buch.de/\",width=130] | http://clojure-buch."
-"de/[Clojure] + by Stefan Kamphausen, Tim Oliver Kaiser + Sep 20, 2010"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:174
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51dWGdAPwUL._SL160.jpg[Practical Clojure, link=\"http://a.co/"
-"fWbYqs5\"] | http://a.co/fWbYqs5[Practical Clojure] + by Luke VanderHart, Stuart Sierra + Jun 1, 2010"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51Bvd25CstL._SL160.jpg[Programming Clojure 3rd edition,link=\"http://a.co/bSxW6A6\"]\n"
+"| http://a.co/bSxW6A6[Programming Clojure 3rd edition] +\n"
+"by Alex Miller, Stuart Halloway, Aaron Bedra +\n"
+"Feb 21, 2018\n"
+"\n"
+"| image::https://s3.amazonaws.com/titlepages.leanpub.com/elementsofclojure/small[Elements of Clojure,link=\"https://leanpub.com/elementsofclojure\"]\n"
+"| https://leanpub.com/elementsofclojure[Elements of Clojure] +\n"
+"by Zachary Tellman +\n"
+"Sep 27, 2017\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/41k50H6VpaL._SL160.jpg[ClojureScript Unraveled,link=\"http://a.co/cDfN4n4\"]\n"
+"| http://a.co/cDfN4n4[Quick Clojure: Effective Functional Programming] +\n"
+"by Mark McDonnell +\n"
+"Aug 23, 2017\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/518xLvhHZ1L._SL160.jpg[Web Development with Clojure,link=\"http://a.co/c2gI4l2\"]\n"
+"| http://a.co/c2gI4l2[Web Development with Clojure] +\n"
+"by Dmitri Sotnikov +\n"
+"Aug 23, 2016\n"
+"\n"
+"| image::https://s3.amazonaws.com/titlepages.leanpub.com/clojurescript-unraveled/small[ClojureScript Unraveled,link=\"https://leanpub.com/clojurescript-unraveled\"]\n"
+"| https://leanpub.com/clojurescript-unraveled[ClojureScript Unraveled] +\n"
+"by Andrey Antukh, Alejandro Gómez +\n"
+"Jul 25, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51EwRiXh4ZL._SL160.jpg[Learning ClojureScript, link=\"http://a.co/2X3MJn2\"]\n"
+"| http://a.co/2X3MJn2[Learning ClojureScript] +\n"
+"by W. David Jarvis, Rafik Naccache, Allen Rohner +\n"
+"Jun 30, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51iq-PKIZ8L._SL160.jpg[Professional Clojure, link=\"http://a.co/bSHZ7X3\"]\n"
+"| http://a.co/bSHZ7X3[Professional Clojure] +\n"
+"by Jeremy Anderson, Michael Gaare, Justin Holguín, Nick Bailey, and Timothy Pratley +\n"
+"Jun 7, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/61TJZjnjO0L._SL160.jpg[Mastering Clojure, link=\"http://a.co/bTLhJ2d\"]\n"
+"| http://a.co/bTLhJ2d[Mastering Clojure] +\n"
+"by Akhil Wali +\n"
+"Mar 28, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/61p47dd81cL._SL160.jpg[Clojure for Java Developers, link=\"http://a.co/029aVrm\"]\n"
+"| http://a.co/029aVrm[Clojure for Java Developers] +\n"
+"by Eduardo Diaz +\n"
+"Feb 23, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51ofF2ckdkL._SL160.jpg[Clojure for Finance, link=\"http://a.co/fbHnhEM\"]\n"
+"| http://a.co/fbHnhEM[Clojure for Finance] +\n"
+"by Timothy Washington +\n"
+"Jan 11, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51QWOEjmtIL._SL160.jpg[Clojure In Action, link=\"http://a.co/a4hDbTn\"]\n"
+"| http://a.co/a4hDbTn[Clojure In Action] +\n"
+"by Amit Rathore +\n"
+"Jan 1, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/6112vbQYDLL._SL160.jpg[Clojure for the Brave and True,link=\"http://a.co/bsviqV7\"]\n"
+"| http://a.co/bsviqV7[Clojure for the Brave and True] +\n"
+"by Daniel Higginbotham +\n"
+"Oct 23, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51aMgNS%2BK7L._SL160.jpg[Clojure Recipes,link=\"http://a.co/clSHVQi\"]\n"
+"| http://a.co/clSHVQi[Clojure Recipes] +\n"
+"by Julian Gamble +\n"
+"Oct 23, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/41iH5aTHB3L._SL160.jpg[Clojure Applied,link=\"http://a.co/1HL2XPF\"]\n"
+"| http://a.co/1HL2XPF[Clojure Applied: From Practice to Practitioner] +\n"
+"by Ben Vandgrift, Alex Miller +\n"
+"Sept 6, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51ki-47i6bL._SL160.jpg[Clojure for Data Science,link=\"http://a.co/idtKjhS\"]\n"
+"| http://a.co/idtKjhS[Clojure for Data Science] +\n"
+"by Henry Garner +\n"
+"Sept 3, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51Nym1wJXVL._SL160.jpg[Clojure High Performance Programming,link=\"http://a.co/7adcmsl\"]\n"
+"| http://a.co/7adcmsl[Clojure High Performance Programming] +\n"
+"by Shantanu Kumar +\n"
+"Sept 1, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/515vh5czqnL._SL160.jpg[Clojure Data Structures and Algorithms,link=\"http://a.co/g7JAFAS\"]\n"
+"| http://a.co/g7JAFAS[Clojure Data Structures and Algorithms] +\n"
+"by Rafik Naccache +\n"
+"Aug 19, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/5122uV93jfL._SL160.jpg[Living Clojure,link=\"http://a.co/1m2Zt4p\"]\n"
+"| http://a.co/1m2Zt4p[Living Clojure] +\n"
+"by Carin Meier +\n"
+"Apr 30, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51l1oGz9N7L._SL160.jpg[Clojure Reactive Programming,link=\"http://a.co/fhyaFka\"]\n"
+"| http://a.co/fhyaFka[Clojure Reactive Programming] +\n"
+"by Leonardo Borges +\n"
+"Mar 24, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51XnilmUaIL._SL160.jpg[Clojure Web Development Essentials,link=\"http://a.co/2FlRxd5\"]\n"
+"| http://a.co/2FlRxd5[Clojure Web Development Essentials] +\n"
+"by Ryan Baldwin +\n"
+"Feb 16, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51-B3kElSiL._SL160.jpg[Clojure Data Analysis Cookbook, link=\"http://a.co/gIwPEkt\"]\n"
+"| http://a.co/gIwPEkt[Clojure Data Analysis Cookbook] +\n"
+"by Eric Rochester +\n"
+"Jan 22, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51nhUEYSLhL._SL160.jpg[Mastering Clojure Macros,link=\"http://a.co/4VjjiQJ\"]\n"
+"| http://a.co/4VjjiQJ[Mastering Clojure Macros] +\n"
+"by Colin Jones +\n"
+"Sept 5, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/518RxlXpXsL._SL160.jpg[The Joy of Clojure,link=\"http://a.co/evdNcOs\"]\n"
+"| http://a.co/evdNcOs[The Joy of Clojure] +\n"
+"by Michael Fogus, Chris Houser +\n"
+"Jun 13, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51gyxyvmX3L._SL160.jpg[Mastering Clojure Data Analysis,link=\"http://a.co/bYwhMwH\"]\n"
+"| http://a.co/bYwhMwH[Mastering Clojure Data Analysis] +\n"
+"by Eric Rochester +\n"
+"May 26, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51Af%2B5qKOeL._SL160.jpg[Clojure for Machine Learning,link=\"http://a.co/7PRmDOK\"]\n"
+"| http://a.co/7PRmDOK[Clojure for Machine Learning] +\n"
+"by Akhil Wali +\n"
+"Apr 24, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51NPZu-5PiL._SL160.jpg[Clojure Cookbook, link=\"http://a.co/1K6SZSI\"]\n"
+"| http://a.co/1K6SZSI[Clojure Cookbook] +\n"
+"by Luke VanderHart and Ryan Neufeld +\n"
+"Mar 24, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/515hwMhZELL._SL160.jpg[Clojure for Domain-specific Languages,link=\"http://a.co/3rwXJkx\"]\n"
+"| http://a.co/3rwXJkx[Clojure for Domain-specific Languages] +\n"
+"by Ryan Kelker +\n"
+"Dec 18, 2013\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51i1Cn-IqdL._SL160.jpg[Functional Programming Patterns in Scala and Clojure,link=\"http://a.co/2J3jvLX\"]\n"
+"| http://a.co/2J3jvLX[Functional Programming Patterns in Scala and Clojure] +\n"
+"by Michael Bevilacqua-Linn +\n"
+"Nov 2, 2013\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51KgF%2B-38WL._SL160.jpg[ClojureScript: Up and Running,link=\"http://a.co/74IUDUu\"]\n"
+"| http://a.co/74IUDUu[ClojureScript: Up and Running] +\n"
+"by Stuart Sierra, Luke VanderHart +\n"
+"Nov 10, 2012\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/41sY2b6MKiL._SL160.jpg[Clojure Programming,link=\"http://a.co/jiaX8tX\"]\n"
+"| http://a.co/jiaX8tX[Clojure Programming] +\n"
+"by Chas Emerick, Brian Carper, Christophe Grand +\n"
+"Apr 22, 2012\n"
+"\n"
+"| image::http://clojure-buch.de/cover.jpg[Clojure,link=\"http://clojure-buch.de/\",width=130]\n"
+"| http://clojure-buch.de/[Clojure] +\n"
+"by Stefan Kamphausen, Tim Oliver Kaiser +\n"
+"Sep 20, 2010\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51dWGdAPwUL._SL160.jpg[Practical Clojure, link=\"http://a.co/fWbYqs5\"]\n"
+"| http://a.co/fWbYqs5[Practical Clojure] +\n"
+"by Luke VanderHart, Stuart Sierra +\n"
+"Jun 1, 2010\n"
+"\n"
 msgstr ""

--- a/i18n/po/content/community/companies/ja.po
+++ b/i18n/po/content/community/companies/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,12 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/community/books.adoc:14 en/content/community/books.adoc:175 en/content/community/companies.adoc:14
-#: en/content/community/companies.adoc:15
-msgid "|==="
-msgstr ""
 
 #. type: Title =
 #: en/content/community/companies.adoc:1
@@ -45,4 +39,10 @@ msgstr ""
 #: en/content/community/companies.adoc:11
 msgid ""
 "Also, check out the <<success_stories#,Clojure Success Stories>> and <<community_stories#,Community Stories>> pages!"
+msgstr ""
+
+#. type: Table
+#: en/content/community/companies.adoc:15
+#, no-wrap
+msgid "include::companies.csv[]\n"
 msgstr ""

--- a/i18n/po/content/community/editing/ja.po
+++ b/i18n/po/content/community/editing/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
-"PO-Revision-Date: 2019-02-18 19:56+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 00:53+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -41,6 +41,7 @@ msgstr "/clojure-site-ja/images/content/reference/transducers/xf.png"
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:49 en/content/community/editing.adoc:172
+#: en/content/guides/learn/sequential_colls.adoc:102
 #, no-wrap
 msgid "Lists"
 msgstr "リスト"
@@ -122,12 +123,18 @@ msgstr ""
 msgid "Text markup"
 msgstr ""
 
-#. type: Plain text
-#: en/content/community/editing.adoc:59
+#. type: Table
+#: en/content/community/editing.adoc:58
+#, no-wrap
 msgid ""
-"|=== | markup | effect | pass:[_italic_] | _italic_ | pass:[*bold*] | *bold* | pass:[_**italic and bold**_] | "
-"_**italic and bold**_ | pass:[`inline code`] | `inline code` | pass:[(C) (R) (TM)] | (C) (R) (TM)  | pass:[-- ...] | "
-"-- ...  | pass:[-> <- => <=] | -> <- => <= |==="
+"| markup | effect\n"
+"| pass:[_italic_] | _italic_\n"
+"| pass:[*bold*] | *bold*\n"
+"| pass:[_**italic and bold**_] | _**italic and bold**_\n"
+"| pass:[`inline code`] | `inline code`\n"
+"| pass:[(C) (R) (TM)] | (C) (R) (TM)\n"
+"| pass:[-- ...] | -- ...\n"
+"| pass:[-> <- => <=] | -> <- => <=\n"
 msgstr ""
 
 #. type: Plain text
@@ -352,8 +359,18 @@ msgid "first"
 msgstr ""
 
 #. type: Plain text
+#: en/content/community/editing.adoc:187
+msgid "second"
+msgstr "second"
+
+#. type: Plain text
+#: en/content/community/editing.adoc:188
+msgid "nested"
+msgstr ""
+
+#. type: Plain text
 #: en/content/community/editing.adoc:189
-msgid "second ** nested *** more nested"
+msgid "more nested"
 msgstr ""
 
 #. type: Plain text
@@ -440,21 +457,14 @@ msgid ""
 "Tables are another large Asciidoc topic with extensive formatting options. This is a basic table example however:"
 msgstr ""
 
-#. type: delimited block -
-#: en/content/community/editing.adoc:235
+#. type: Table
+#: en/content/community/editing.adoc:234 en/content/community/editing.adoc:242
 #, no-wrap
 msgid ""
 "[options=\"header\"]\n"
-"|===\n"
 "| col1 | col2\n"
 "| a | b\n"
 "| b | c\n"
-"|===\n"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/editing.adoc:243
-msgid "|=== | col1 | col2 | a | b | b | c |==="
 msgstr ""
 
 #. type: Title ==

--- a/i18n/po/content/community/etiquette/ja.po
+++ b/i18n/po/content/community/etiquette/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:15+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -101,11 +101,28 @@ msgid "Leave people out of it"
 msgstr ""
 
 #. type: Plain text
+#: en/content/community/etiquette.adoc:29
+msgid "Avoid rhetorical devices:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/community/etiquette.adoc:30
+msgid "Superfluous or opinion-laden adjectives"
+msgstr ""
+
+#. type: Plain text
+#: en/content/community/etiquette.adoc:31
+msgid "Claims to speak for the community, or that everyone agrees with you."
+msgstr ""
+
+#. type: Plain text
+#: en/content/community/etiquette.adoc:32
+msgid "Threats of what will happen unless things go your way"
+msgstr ""
+
+#. type: Plain text
 #: en/content/community/etiquette.adoc:33
-msgid ""
-"Avoid rhetorical devices: ** Superfluous or opinion-laden adjectives ** Claims to speak for the community, or that "
-"everyone agrees with you.  ** Threats of what will happen unless things go your way ** Any flavor of 'the sky is "
-"falling'"
+msgid "Any flavor of 'the sky is falling'"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/po/content/community/training/ja.po
+++ b/i18n/po/content/community/training/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:18+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,16 +47,21 @@ msgid ""
 "individuals that offer Clojure training courses."
 msgstr ""
 
-#. type: Plain text
-#: en/content/community/training.adoc:28
+#. type: Table
+#: en/content/community/training.adoc:27
+#, no-wrap
 msgid ""
-"|=== | Company | Location | Courses | Link | contact | Cognitect | North America | All levels | https://cognitect.com/"
-"services.html | sales@cognitect.com + +1 919.283.2748 | BraveAndTrue | North America | All levels | https://www."
-"braveclojure.com/training | daniel@braveclojure.com | Nilenso | India | Enterprise Clojure | https://nilenso.com | "
-"hello@nilenso.com + tel:+918040937123 | Starweaver | Global | Clojure in a Nutshell | https://www.starweaver.com | "
-"USA: +1-646-883-1460 + UK: +44 20 3289 3277 + helpdesk@starweaver.com | Peter Taoussanis | Europe | Enterprise "
-"Clojure | https://www.taoensso.com | ptaoussanis@taoensso.com | Adam Bard | North America | Clojure Training | http://"
-"clojuretraining.ca | learnclojure@adambard.com |==="
+"| Company | Location | Courses | Link | contact\n"
+"| Cognitect | North America | All levels | https://cognitect.com/services.html | sales@cognitect.com +\n"
+"+1 919.283.2748\n"
+"| BraveAndTrue | North America | All levels | https://www.braveclojure.com/training | daniel@braveclojure.com\n"
+"| Nilenso | India | Enterprise Clojure | https://nilenso.com | hello@nilenso.com +\n"
+"tel:+918040937123\n"
+"| Starweaver | Global | Clojure in a Nutshell | https://www.starweaver.com | USA: +1-646-883-1460 +\n"
+"UK: +44 20 3289 3277 +\n"
+"helpdesk@starweaver.com\n"
+"| Peter Taoussanis | Europe | Enterprise Clojure | https://www.taoensso.com | ptaoussanis@taoensso.com\n"
+"| Adam Bard | North America | Clojure Training | http://clojuretraining.ca | learnclojure@adambard.com\n"
 msgstr ""
 
 #. type: Title ==
@@ -76,13 +81,14 @@ msgstr ""
 msgid "Online courses"
 msgstr ""
 
-#. type: Plain text
-#: en/content/community/training.adoc:44
+#. type: Table
+#: en/content/community/training.adoc:43
+#, no-wrap
 msgid ""
-"|=== | Link | Short description | https://lambdaisland.com | A series of video tutorial about web development using "
-"ClojureScript and Clojure | https://purelyfunctional.tv | Our mission is to help people thrive with Functional "
-"Programming | https://www.udemy.com/learning-clojure | Will teach you how to write Clojure code and structure Clojure "
-"products |==="
+"| Link | Short description\n"
+"| https://lambdaisland.com | A series of video tutorial about web development using ClojureScript and Clojure\n"
+"| https://purelyfunctional.tv | Our mission is to help people thrive with Functional Programming\n"
+"| https://www.udemy.com/learning-clojure | Will teach you how to write Clojure code and structure Clojure products\n"
 msgstr ""
 
 #. type: Title ===

--- a/i18n/po/content/guides/comparators/ja.po
+++ b/i18n/po/content/guides/comparators/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -85,36 +85,44 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/guides/comparators.adoc:41
+msgid "Write either a 3-way comparator or a boolean comparator:"
+msgstr ""
+
+#. type: Plain text
 #: en/content/guides/comparators.adoc:42
+msgid "A 3-way comparator takes 2 values, _x_ and _y_, and returns a Java 32-bit _int_ that is negative if"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/comparators.adoc:44
 msgid ""
-"Write either a 3-way comparator or a boolean comparator: ** A 3-way comparator takes 2 values, _x_ and _y_, and "
-"returns a Java 32-bit _int_ that is negative if"
+"_x_ comes before _y_, positive if _x_ comes after _y_, or 0 if they are equal. Use values -1, 0, and 1 if you have no "
+"reason to prefer other return values."
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/comparators.adoc:45
+msgid "A boolean comparator takes 2 values, _x_ and _y_, and returns true if _x_ comes before _y_, or"
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/comparators.adoc:48
-#, no-wrap
 msgid ""
-"_x_ comes before _y_, positive if _x_ comes after _y_, or 0 if they are equal. Use values -1, 0, and 1\n"
-"if you have no reason to prefer other return values.\n"
-"** A boolean comparator takes 2 values, _x_ and _y_, and returns true if _x_ comes before _y_, or\n"
-"    false otherwise (including if _x_ and _y_ are equal). `<` and `>` are good examples. `\\<=`\n"
-"    and `>=` are not. Performance note: your boolean comparator may be called twice to distinguish\n"
-"    between the \"comes after\" or \"equals\" cases.\n"
+"false otherwise (including if _x_ and _y_ are equal). `<` and `>` are good examples. `\\<=` and `>=` are not. "
+"Performance note: your boolean comparator may be called twice to distinguish between the \"comes after\" or \"equals"
+"\" cases."
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/comparators.adoc:49
-#, no-wrap
-msgid "Reverse the sort by reversing the order that you give the arguments to an existing comparator.\n"
+msgid "Reverse the sort by reversing the order that you give the arguments to an existing comparator."
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/comparators.adoc:51
-#, no-wrap
 msgid ""
-"Compare equal-length Clojure vectors containing \"sort keys\" in order to do a multi-field comparison\n"
-"between values.\n"
+"Compare equal-length Clojure vectors containing \"sort keys\" in order to do a multi-field comparison between values."
 msgstr ""
 
 #. type: Plain text

--- a/i18n/po/content/guides/deps_and_cli/ja.po
+++ b/i18n/po/content/guides/deps_and_cli/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
-"PO-Revision-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 01:31+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/guides/deps_and_cli.adoc:1
@@ -59,17 +34,13 @@ msgstr ""
 
 #. type: Plain text
 #: en/content/guides/deps_and_cli.adoc:15
-#, fuzzy
-#| msgid "With no options or args, runs an interactive Read-Eval-Print Loop"
 msgid "Running an interactive REPL (Read-Eval-Print Loop)"
-msgstr "オプションと引数の指定がない場合、インタラクティブな REPL (Read-Eval-Print Loop) を実行する"
+msgstr "インタラクティブなREPL (Read-Eval-Print Loop)を実行する"
 
 #. type: Plain text
 #: en/content/guides/deps_and_cli.adoc:16
-#, fuzzy
-#| msgid "Clojure programming"
 msgid "Running Clojure programs"
-msgstr "Clojureプログラミング"
+msgstr "Clojureプログラムを実行する"
 
 #. type: Title ==
 #: en/content/guides/deps_and_cli.adoc:17 en/content/guides/repl/basic_usage.adoc:17
@@ -196,10 +167,9 @@ msgstr ""
 
 #. type: Title ==
 #: en/content/guides/deps_and_cli.adoc:69
-#, fuzzy, no-wrap
-#| msgid "Functional programming"
+#, no-wrap
 msgid "Writing a program"
-msgstr "関数型プログラミング"
+msgstr "プログラムを書く"
 
 #. type: Plain text
 #: en/content/guides/deps_and_cli.adoc:72
@@ -357,10 +327,9 @@ msgstr ""
 
 #. type: Title ==
 #: en/content/guides/deps_and_cli.adoc:163
-#, fuzzy, no-wrap
-#| msgid "Using Libs"
+#, no-wrap
 msgid "Using git libraries"
-msgstr "ライブラリの使用"
+msgstr "gitのライブラリを利用する"
 
 #. type: Plain text
 #: en/content/guides/deps_and_cli.adoc:166
@@ -455,10 +424,9 @@ msgstr ""
 
 #. type: Title ==
 #: en/content/guides/deps_and_cli.adoc:207
-#, fuzzy, no-wrap
-#| msgid "For example:"
+#, no-wrap
 msgid "Other examples"
-msgstr "例:"
+msgstr "その他の例"
 
 #. type: Plain text
 #: en/content/guides/deps_and_cli.adoc:210

--- a/i18n/po/content/guides/destructuring/ja.po
+++ b/i18n/po/content/guides/destructuring/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/macros.adoc:1 en/content/guides/spec.adoc:782 en/content/guides/destructuring.adoc:522

--- a/i18n/po/content/guides/faq/ja.po
+++ b/i18n/po/content/guides/faq/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/deps_and_cli.adoc:1 en/content/guides/faq.adoc:203

--- a/i18n/po/content/guides/getting_started/ja.po
+++ b/i18n/po/content/guides/getting_started/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-15 14:33+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/guides/getting_started.adoc:1

--- a/i18n/po/content/guides/guides/ja.po
+++ b/i18n/po/content/guides/guides/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
-"PO-Revision-Date: 2016-06-27 08:47+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 02:44+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -77,10 +77,8 @@ msgstr ""
 
 #. type: Plain text
 #: en/content/guides/guides.adoc:21
-#, fuzzy
-#| msgid "Parsing/destructuring"
 msgid "<<destructuring#,Destructuring>>"
-msgstr "パース処理/分配束縛"
+msgstr "<<destructuring#,分配束縛>>"
 
 #. type: Plain text
 #: en/content/guides/guides.adoc:22
@@ -102,11 +100,11 @@ msgstr ""
 msgid "<<deps_and_cli#,Deps and CLI>>"
 msgstr ""
 
-#. type: Title ===
-#: en/content/guides/guides.adoc:29
+#. type: Plain text
+#: en/content/guides/guides.adoc:29 en/content/about/rationale.adoc:68
 #, no-wrap
 msgid "Libraries"
-msgstr ""
+msgstr "ライブラリ"
 
 #. type: Plain text
 #: en/content/guides/guides.adoc:31

--- a/i18n/po/content/guides/higher_order_functions/ja.po
+++ b/i18n/po/content/guides/higher_order_functions/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
-"PO-Revision-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 00:55+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -16,37 +16,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
-
 #. type: Title ==
 #: en/content/guides/higher_order_functions.adoc:1 en/content/guides/higher_order_functions.adoc:23
-#, fuzzy, no-wrap
-#| msgid "Related functions"
+#, no-wrap
 msgid "Higher Order Functions"
-msgstr "関連する関数"
+msgstr "高階関数"
 
 #. type: Plain text
 #: en/content/guides/higher_order_functions.adoc:4
@@ -55,8 +29,7 @@ msgstr ""
 
 #. type: Title ==
 #: en/content/guides/higher_order_functions.adoc:12
-#, fuzzy, no-wrap
-#| msgid "First-class functions"
+#, no-wrap
 msgid "First Class Functions"
 msgstr "ファーストクラスの関数"
 
@@ -109,17 +82,14 @@ msgstr ""
 
 #. type: Title ===
 #: en/content/guides/higher_order_functions.adoc:38
-#, fuzzy, no-wrap
-#| msgid "Functional Programming"
+#, no-wrap
 msgid "Functions as Arguments"
-msgstr "関数型プログラミング"
+msgstr "引数としての関数"
 
 #. type: Plain text
 #: en/content/guides/higher_order_functions.adoc:41
-#, fuzzy
-#| msgid "Related functions"
 msgid "Let's look at two functions"
-msgstr "関連する関数"
+msgstr "2つの関数を見てみよう"
 
 #. type: delimited block -
 #: en/content/guides/higher_order_functions.adoc:47
@@ -178,10 +148,9 @@ msgstr ""
 
 #. type: Title ==
 #: en/content/guides/higher_order_functions.adoc:78
-#, fuzzy, no-wrap
-#| msgid "eduction"
+#, no-wrap
 msgid "Function Literals"
-msgstr "eduction"
+msgstr "関数リテラル"
 
 #. type: Plain text
 #: en/content/guides/higher_order_functions.adoc:83

--- a/i18n/po/content/guides/learn/flow/ja.po
+++ b/i18n/po/content/guides/learn/flow/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
-"PO-Revision-Date: 2019-05-27 21:19+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 01:04+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -15,27 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ===
 #: en/content/guides/reader_conditionals.adoc:120 en/content/guides/learn/flow.adoc:285
@@ -103,7 +82,9 @@ msgstr ""
 msgid ""
 "In Clojure, however, everything is an expression! _Everything_ returns a value, and a block of multiple expressions "
 "returns the last value. Expressions that exclusively perform side-effects return `nil`."
-msgstr "しかしClojureでは、あらゆるものが式なのだ! _あらゆるもの_ が値を返し、複数の式のブロックは最後の値を返す。副作用のみを実行する式は `nil` を返す。"
+msgstr ""
+"しかしClojureでは、あらゆるものが式なのだ! _あらゆるもの_ が値を返し、複数の式のブロックは最後の値を返す。副作用のみを"
+"実行する式は `nil` を返す。"
 
 #. type: Title ==
 #: en/content/guides/learn/flow.adoc:35
@@ -121,7 +102,9 @@ msgstr "したがって、フロー制御のオペレータもまた式なのだ
 msgid ""
 "Flow control operators are composable, so we can use them anywhere. This leads to less duplicate code, as well as "
 "fewer intermediate variables."
-msgstr "フロー制御のオペレータは組み合わせ可能なので、どこでも使うことができる。これにより、重複コードが減り、中間変数が少なくなる。"
+msgstr ""
+"フロー制御のオペレータは組み合わせ可能なので、どこでも使うことができる。これにより、重複コードが減り、中間変数が少なく"
+"なる。"
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:42
@@ -130,7 +113,11 @@ msgid ""
 "be discussing macros today, but you can read more about them at <<xref/../../../reference/macros#,Macros>>, https://"
 "aphyr.com/posts/305-clojure-from-the-ground-up-macros[Clojure from the Ground Up], or http://www.braveclojure.com/"
 "writing-macros/[Clojure for the Brave and True], among many other places."
-msgstr "フロー制御のオペレータはマクロによって拡張することもできる。マクロはユーザのコードによってコンパイラを拡張することを可能にする。今日はマクロについて議論しないが、詳しくは <<xref/../../../reference/macros#,マクロ>> 、 https://aphyr.com/posts/305-clojure-from-the-ground-up-macros[Clojure from the Ground Up] 、 http://www.braveclojure.com/writing-macros/[Clojure for the Brave and True] ほか多くの場所で読むことができる。"
+msgstr ""
+"フロー制御のオペレータはマクロによって拡張することもできる。マクロはユーザのコードによってコンパイラを拡張することを可"
+"能にする。今日はマクロについて議論しないが、詳しくは <<xref/../../../reference/macros#,マクロ>> 、 https://aphyr.com/"
+"posts/305-clojure-from-the-ground-up-macros[Clojure from the Ground Up] 、 http://www.braveclojure.com/writing-macros/"
+"[Clojure for the Brave and True] ほか多くの場所で読むことができる。"
 
 #. type: Title ===
 #: en/content/guides/learn/flow.adoc:43
@@ -143,7 +130,9 @@ msgstr "`if`"
 msgid ""
 "`if` is the most important conditional expression - it consists of a condition, a \"then\", and an \"else\". `if` "
 "will only evaluate the branch selected by the conditional."
-msgstr "`if` は最も重要な制御式であり、条件と\"then\"と\"else\"で構成されている。 `if` は条件によって選ばれた分岐だけを評価する。"
+msgstr ""
+"`if` は最も重要な制御式であり、条件と\"then\"と\"else\"で構成されている。 `if` は条件によって選ばれた分岐だけを評価す"
+"る。"
 
 #. type: delimited block -
 #: en/content/guides/learn/flow.adoc:51
@@ -176,7 +165,9 @@ msgstr "真"
 msgid ""
 "In Clojure, all values are logically true or false. The only \"false\" values are `false` and `nil` - all other "
 "values are logically true."
-msgstr "Clojureでは、すべての値は論理的に真または偽のどちらかだ。 `false` と `nil` の値だけが「偽」であり、その他のすべての値は論理的に真だ。"
+msgstr ""
+"Clojureでは、すべての値は論理的に真または偽のどちらかだ。 `false` と `nil` の値だけが「偽」であり、その他のすべての値"
+"は論理的に真だ。"
 
 #. type: delimited block -
 #: en/content/guides/learn/flow.adoc:74
@@ -254,7 +245,9 @@ msgid ""
 "`when` is an `if` with only a `then` branch. It checks a condition and then evaluates any number of statements as a "
 "body (so no `do` is required). The value of the last expression is returned. If the condition is false, nil is "
 "returned."
-msgstr "`when` は `then` の分岐だけを持つ `if` だ。条件をチェックし、本体部として任意個の文を評価する(なので `do` は必要ない)。 最後の式の値が返る。条件が偽の場合、 nilが返る。"
+msgstr ""
+"`when` は `then` の分岐だけを持つ `if` だ。条件をチェックし、本体部として任意個の文を評価する(なので `do` は必要な"
+"い)。 最後の式の値が返る。条件が偽の場合、 nilが返る。"
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:97
@@ -282,7 +275,8 @@ msgstr "`cond`"
 msgid ""
 "`cond` is a series of tests and expressions. Each test is evaluated in order and the expression is evaluated and "
 "returned for the first true test."
-msgstr "`cond` はテストと式が並んだものだ。個々のテストは順に評価され、最初に真になるテストに対応する式が評価されて返る。"
+msgstr ""
+"`cond` はテストと式が並んだものだ。個々のテストは順に評価され、最初に真になるテストに対応する式が評価されて返る。"
 
 #. type: delimited block -
 #: en/content/guides/learn/flow.adoc:114
@@ -309,7 +303,9 @@ msgstr "`cond` と `else`"
 msgid ""
 "If no test is satisfied, nil is returned. A common idiom is to use a final test of `:else`. Keywords (like `:else`) "
 "always evaluate to true so this will always be selected as a default."
-msgstr "いずれのテストも満たさない場合、nilが返る。最後のテストに `:else` を使うのが一般的なイディオムだ。 `:else` のようなキーワードは常に真と評価されるため、これが常にデフォルトとして選ばれる。"
+msgstr ""
+"いずれのテストも満たさない場合、nilが返る。最後のテストに `:else` を使うのが一般的なイディオムだ。 `:else` のような"
+"キーワードは常に真と評価されるため、これが常にデフォルトとして選ばれる。"
 
 #. type: delimited block -
 #: en/content/guides/learn/flow.adoc:127
@@ -338,7 +334,9 @@ msgstr "`case`"
 msgid ""
 "`case` compares an argument to a series of values to find a match. This is done in constant (not linear) time! "
 "However, each value must be a compile-time literal (numbers, strings, keywords, etc)."
-msgstr "`case` は引数を一連の値と比較し一致するものを探す。これは(線形ではなく)定数時間で終わる! しかし、個々の値はコンパイル時リテラル(数値、文字列、キーワードなど)でなければならない。"
+msgstr ""
+"`case` は引数を一連の値と比較し一致するものを探す。これは(線形ではなく)定数時間で終わる! しかし、個々の値はコンパイル"
+"時リテラル(数値、文字列、キーワードなど)でなければならない。"
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:134
@@ -589,25 +587,34 @@ msgid "Clojure provides recur and the sequence abstraction"
 msgstr "Clojureはrecurとシーケンス抽象を提供している"
 
 #. type: Plain text
+#: en/content/guides/learn/flow.adoc:241
+msgid "`recur` is \"classic\" recursion"
+msgstr "`recur` は「古典的な」再帰だ"
+
+#. type: Plain text
 #: en/content/guides/learn/flow.adoc:242
-msgid "`recur` is \"classic\" recursion ** Consumers don't control it, considered a lower-level facility"
-msgstr ""
-"`recur` は「古典的な」再帰だ\n"
-"** 利用者がコントロールできず、低レベルな機能と考えられる"
+msgid "Consumers don't control it, considered a lower-level facility"
+msgstr "利用者がコントロールできず、低レベルな機能と考えられる"
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:243
+msgid "Sequences represent iteration as values"
+msgstr "シーケンスは繰り返しを値として表現する"
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:244
-msgid "Sequences represent iteration as values ** Consumers can partially iterate"
-msgstr ""
-"シーケンスは繰り返しを値として表現する\n"
-"** 利用者が部分的に繰り返すことができる"
+msgid "Consumers can partially iterate"
+msgstr "利用者が部分的に繰り返すことができる"
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:245
+msgid "Reducers represent iteration as function composition"
+msgstr "reducerは繰り返しを関数合成として表現する"
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:246
-msgid "Reducers represent iteration as function composition ** Added in Clojure 1.5, not covered here"
-msgstr ""
-"reducerは繰り返しを関数合成として表現する\n"
-"** Clojure 1.5で追加されたが、ここでは扱わない"
+msgid "Added in Clojure 1.5, not covered here"
+msgstr "Clojure 1.5で追加されたが、ここでは扱わない"
 
 #. type: Title ===
 #: en/content/guides/learn/flow.adoc:247
@@ -616,12 +623,19 @@ msgid "`loop` and `recur`"
 msgstr "`loop` と `recur`"
 
 #. type: Plain text
+#: en/content/guides/learn/flow.adoc:250
+msgid "Functional looping construct"
+msgstr "関数型のループ構文"
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:251
+msgid "`loop` defines bindings"
+msgstr "`loop` は束縛を定義する"
+
+#. type: Plain text
 #: en/content/guides/learn/flow.adoc:252
-msgid "Functional looping construct ** `loop` defines bindings ** `recur` re-executes `loop` with new bindings"
-msgstr ""
-"関数型のループ構文\n"
-"** `loop` は束縛を定義する\n"
-"** `recur` は新しい束縛で `loop` を再実行する"
+msgid "`recur` re-executes `loop` with new bindings"
+msgstr "`recur` は新たな束縛で `loop` を再実行する"
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:253
@@ -674,19 +688,29 @@ msgid "`recur` for recursion"
 msgstr "再帰のための `recur`"
 
 #. type: Plain text
+#: en/content/guides/learn/flow.adoc:277
+msgid "`recur` must be in \"tail position\""
+msgstr "`recur` は「末尾位置」になければならない式"
+
+#. type: Plain text
 #: en/content/guides/learn/flow.adoc:278
-msgid "`recur` must be in \"tail position\" ** The last expression in a branch"
-msgstr ""
-"`recur` は「末尾位置」になければならない\n"
-"** 分岐の最後の式"
+msgid "The last expression in a branch"
+msgstr "分岐の最後の式"
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:279
+msgid "`recur` must provide values for all bound symbols by position"
+msgstr "`recur` はすべての束縛シンボルに対応する値を与えなければならない数"
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:280
+msgid "Loop bindings"
+msgstr "loopの束縛"
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:281
-msgid "`recur` must provide values for all bound symbols by position ** Loop bindings ** defn/fn arguments"
-msgstr ""
-"`recur` はすべての束縛シンボルに対応する値を与えなければならない\n"
-"** loopの束縛\n"
-"** defn/fnの引数"
+msgid "defn/fn arguments"
+msgstr "defn/fnの引数"
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:282
@@ -752,11 +776,14 @@ msgid "`ex-info` takes a message and a map"
 msgstr "`ex-info` はメッセージとマップをとる"
 
 #. type: Plain text
+#: en/content/guides/learn/flow.adoc:312
+msgid "`ex-data` gets the map back out"
+msgstr "`ex-data` はそのマップを取り出す"
+
+#. type: Plain text
 #: en/content/guides/learn/flow.adoc:313
-msgid "`ex-data` gets the map back out ** Or `nil` if not created with `ex-info`"
-msgstr ""
-"`ex-data` はそのマップを取り出す\n"
-"** もしくは `ex-info` で作られたものでなければ `nil`"
+msgid "Or `nil` if not created with `ex-info`"
+msgstr "もしくは `ex-info` で作られたものでなければ `nil`"
 
 #. type: delimited block -
 #: en/content/guides/learn/flow.adoc:320

--- a/i18n/po/content/guides/learn/functions/ja.po
+++ b/i18n/po/content/guides/learn/functions/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
-"PO-Revision-Date: 2019-02-18 15:06+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 02:33+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -15,27 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/java_interop.adoc:1 en/content/guides/learn/functions.adoc:268
@@ -699,16 +678,23 @@ msgstr "Javaコードを呼び出す"
 msgid "Below is a summary of calling conventions for calling into Java from Clojure:"
 msgstr "以下はClojureからJavaを呼び出すための呼び出し規約(calling conventions)のまとめだ:"
 
-#. type: Plain text
-#: en/content/guides/learn/functions.adoc:283
+#. type: Table
+#: en/content/guides/learn/functions.adoc:282
+#, no-wrap
 msgid ""
-"|=== | Task | Java | Clojure | |Instantiation| `new Widget(\"foo\")` | `(Widget. \"foo\")` | |Instance method| `rnd."
-"next()` | `(.nextInt rnd)` | |Instance field| `object.field` | `(.-field object)` | |Static method| `Math.sqrt(25)` | "
-"`(Math/sqrt 25)` | |Static field| `Math.PI` | `Math/PI` | |==="
+"| Task | Java | Clojure |\n"
+"|Instantiation| `new Widget(\"foo\")` | `(Widget. \"foo\")` | \n"
+"|Instance method| `rnd.next()` | `(.nextInt rnd)` |\n"
+"|Instance field| `object.field` | `(.-field object)` |\n"
+"|Static method| `Math.sqrt(25)` | `(Math/sqrt 25)` |\n"
+"|Static field| `Math.PI` | `Math/PI` |\n"
 msgstr ""
-"|=== | タスク | Java | Clojure | |インスタンス化| `new Widget(\"foo\")` | `(Widget. \"foo\")` | |インスタンスメソッ"
-"ド| `rnd.next()` | `(.nextInt rnd)` | |インスタンスフィールド| `object.field` | `(.-field object)` | |staticメソッド| "
-"`Math.sqrt(25)` | `(Math/sqrt 25)` | |staticフィールド| `Math.PI` | `Math/PI` | |==="
+"| タスク | Java | Clojure |\n"
+"|インスタンス化| `new Widget(\"foo\")` | `(Widget. \"foo\")` |\n"
+"|インスタンスメソッド| `rnd.next()` | `(.nextInt rnd)` |\n"
+"|インスタンスフィールド| `object.field` | `(.-field object)` |\n"
+"|staticメソッド| `Math.sqrt(25)` | `(Math/sqrt 25)` |\n"
+"|staticフィールド| `Math.PI` | `Math/PI` |\n"
 
 #. type: Title ===
 #: en/content/guides/learn/functions.adoc:284

--- a/i18n/po/content/guides/learn/hashed_colls/ja.po
+++ b/i18n/po/content/guides/learn/hashed_colls/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2019-02-19 22:44+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,27 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ====
 #: en/content/reference/reader.adoc:57 en/content/guides/learn/hashed_colls.adoc:82 en/content/about/spec.adoc:198

--- a/i18n/po/content/guides/learn/sequential_colls/ja.po
+++ b/i18n/po/content/guides/learn/sequential_colls/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2019-02-18 19:57+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,27 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:49 en/content/community/editing.adoc:172

--- a/i18n/po/content/guides/learn/syntax/ja.po
+++ b/i18n/po/content/guides/learn/syntax/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
-"PO-Revision-Date: 2019-02-13 02:53+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 02:32+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -15,27 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:31 en/content/guides/learn/syntax.adoc:15
@@ -856,10 +835,17 @@ msgstr ""
 "言語を学ぶ際にする最も一般的なことのひとつは値を印字することだ。Clojureは値を印字するためにいくつかの関数を提供してい"
 "る:"
 
-#. type: Plain text
-#: en/content/guides/learn/syntax.adoc:320
-msgid "|=== | | Human-Readable | Machine-Readable | |With newline| println | prn | |Without newline | print | pr | |==="
-msgstr "|=== | | 人間が読める | 機械が読める | | 改行あり | println | prn | | 改行なし | print | pr | |==="
+#. type: Table
+#: en/content/guides/learn/syntax.adoc:319
+#, no-wrap
+msgid ""
+"| | Human-Readable | Machine-Readable |\n"
+"|With newline| println | prn | \n"
+"|Without newline | print | pr |\n"
+msgstr ""
+"| | 人間が読める | 機械が読める |\n"
+"| 改行あり | println | prn |\n"
+"| 改行なし | print | pr |\n"
 
 #. type: Plain text
 #: en/content/guides/learn/syntax.adoc:322

--- a/i18n/po/content/guides/reader_conditionals/ja.po
+++ b/i18n/po/content/guides/reader_conditionals/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,27 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/reference/namespaces.adoc:1 en/content/guides/reader_conditionals.adoc:87 en/content/guides/faq.adoc:133
@@ -274,7 +253,7 @@ msgstr ""
 #: en/content/guides/reader_conditionals.adoc:120 en/content/guides/learn/flow.adoc:285
 #, no-wrap
 msgid "Exception handling"
-msgstr ""
+msgstr "例外処理"
 
 #. type: Plain text
 #: en/content/guides/reader_conditionals.adoc:123

--- a/i18n/po/content/guides/repl/annex_troubleshooting/ja.po
+++ b/i18n/po/content/guides/repl/annex_troubleshooting/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:18+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/guides/repl/annex_troubleshooting.adoc:1

--- a/i18n/po/content/guides/repl/basic_usage/ja.po
+++ b/i18n/po/content/guides/repl/basic_usage/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:18+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/guides/deps_and_cli.adoc:17 en/content/guides/repl/basic_usage.adoc:17

--- a/i18n/po/content/guides/repl/data_visualization_at_the_repl/ja.po
+++ b/i18n/po/content/guides/repl/data_visualization_at_the_repl/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:18+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/guides/repl/annex_troubleshooting.adoc:4 en/content/guides/repl/navigating_namespaces.adoc:4

--- a/i18n/po/content/guides/repl/enhancing_your_repl_workflow/ja.po
+++ b/i18n/po/content/guides/repl/enhancing_your_repl_workflow/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:18+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/guides/repl/annex_troubleshooting.adoc:4 en/content/guides/repl/navigating_namespaces.adoc:4

--- a/i18n/po/content/guides/repl/introduction/ja.po
+++ b/i18n/po/content/guides/repl/introduction/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:18+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/guides/repl/annex_troubleshooting.adoc:4 en/content/guides/repl/navigating_namespaces.adoc:4

--- a/i18n/po/content/guides/repl/launching_a_basic_repl/ja.po
+++ b/i18n/po/content/guides/repl/launching_a_basic_repl/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:18+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ===
 #: en/content/community/libraries.adoc:18 en/content/guides/repl/launching_a_basic_repl.adoc:42

--- a/i18n/po/content/guides/repl/navigating_namespaces/ja.po
+++ b/i18n/po/content/guides/repl/navigating_namespaces/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:18+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/guides/repl/annex_troubleshooting.adoc:4 en/content/guides/repl/navigating_namespaces.adoc:4
@@ -452,7 +427,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/content/guides/repl/navigating_namespaces.adoc:261
-msgid "---- ;; ----------------------------------------------- ;; src/myproject/welcome.clj (ns myproject.welcome"
+msgid "  ;; ----------------------------------------------- ;; src/myproject/welcome.clj (ns myproject.welcome"
 msgstr ""
 
 #. type: Labeled list
@@ -533,8 +508,8 @@ msgstr ""
 #. type: Plain text
 #: en/content/guides/repl/navigating_namespaces.adoc:307
 msgid ""
-"---- $ clj ## APPROACH 2: requiring myproject.welcome, which itself requires myproject.person-names Clojure 1.9.0 "
-"user=> (require '[myproject.welcome])  nil"
+"  $ clj ## APPROACH 2: requiring myproject.welcome, which itself requires myproject.person-names Clojure 1.9.0 user=> "
+"(require '[myproject.welcome])  nil"
 msgstr ""
 
 #. type: Labeled list

--- a/i18n/po/content/guides/spec/ja.po
+++ b/i18n/po/content/guides/spec/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,23 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ====
 #: en/content/reference/sequences.adoc:1 en/content/guides/spec.adoc:513 en/content/about/spec.adoc:234
@@ -1060,24 +1043,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/guides/spec.adoc:489
+msgid "Regular expression - `(s/cat :x double? :y double? :z double?)`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/spec.adoc:490
+msgid "Allows for matching nested structure (not needed here)"
+msgstr ""
+
+#. type: Plain text
 #: en/content/guides/spec.adoc:491
-msgid ""
-"Regular expression - `(s/cat :x double? :y double? :z double?)` ** Allows for matching nested structure (not needed "
-"here)  ** Conforms to map with named keys based on the `cat` tags"
+msgid "Conforms to map with named keys based on the `cat` tags"
 msgstr ""
 
 #. type: Plain text
-#: en/content/guides/spec.adoc:494
-msgid ""
-"Collection - `(s/coll-of double?)` ** Designed for arbitrary size homogenous collections ** Conforms to a vector of "
-"the values"
+#: en/content/guides/spec.adoc:492
+msgid "Collection - `(s/coll-of double?)`"
 msgstr ""
 
 #. type: Plain text
-#: en/content/guides/spec.adoc:497
-msgid ""
-"Tuple - `(s/tuple double? double? double?)` ** Designed for fixed size with known positional \"fields\" ** Conforms "
-"to a vector of the values"
+#: en/content/guides/spec.adoc:493
+msgid "Designed for arbitrary size homogenous collections"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/spec.adoc:494 en/content/guides/spec.adoc:497
+msgid "Conforms to a vector of the values"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/spec.adoc:495
+msgid "Tuple - `(s/tuple double? double? double?)`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/spec.adoc:496
+msgid "Designed for fixed size with known positional \"fields\""
 msgstr ""
 
 #. type: Plain text
@@ -2438,7 +2440,7 @@ msgid "(require '[clojure.spec.test.alpha :as stest])"
 msgstr ""
 
 #. type: Plain text
-#: en/content/guides/spec.adoc:1199 en/content/about/spec.adoc:100
+#: en/content/guides/spec.adoc:1199 en/content/news/2017/12/08/clojure19.adoc:18 en/content/about/spec.adoc:100
 #, no-wrap
 msgid "Instrumentation"
 msgstr "specの組み込み(instrumentation)"

--- a/i18n/po/content/guides/weird_characters/ja.po
+++ b/i18n/po/content/guides/weird_characters/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2017-07-05 16:14+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,22 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:81 en/content/guides/weird_characters.adoc:474

--- a/i18n/po/content/reference/agents/ja.po
+++ b/i18n/po/content/reference/agents/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-10-31 09:13+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73 en/content/reference/namespaces.adoc:24

--- a/i18n/po/content/reference/compilation/ja.po
+++ b/i18n/po/content/reference/compilation/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-06-01 09:26+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/reference/compilation.adoc:1
@@ -112,10 +96,15 @@ msgid "Each file generates a loader class of the same name with \"__init\" appen
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/compilation.adoc:31
+msgid "The static initializer for a loader class produces the same effects as does loading its source file"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/compilation.adoc:32
 msgid ""
-"The static initializer for a loader class produces the same effects as does loading its source file ** You generally "
-"shouldn't need to use these classes directly, as use, require and load will choose between them and more recent source"
+"You generally shouldn't need to use these classes directly, as use, require and load will choose between them and "
+"more recent source"
 msgstr ""
 
 #. type: Plain text
@@ -178,10 +167,13 @@ msgid "Controlling the mapping to an implementing namespace"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/compilation.adoc:44
+msgid "Exposing inherited protected members"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/compilation.adoc:45
-msgid ""
-"Exposing inherited protected members ** Generating more than one named class from a single file, with implementations "
-"in one or more namespaces"
+msgid "Generating more than one named class from a single file, with implementations in one or more namespaces"
 msgstr ""
 
 #. type: Plain text
@@ -211,8 +203,13 @@ msgid "Naming the generated interface"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/compilation.adoc:50
+msgid "Specifying any superintefaces"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/compilation.adoc:51
-msgid "Specifying any superintefaces ** Declaring the signatures of interface methods"
+msgid "Declaring the signatures of interface methods"
 msgstr ""
 
 #. type: Title ==
@@ -244,8 +241,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/compilation.adoc:58
+msgid "For each gen-class:"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/compilation.adoc:59
-msgid "For each gen-class: ** A stub classfile will be produced with the specified name"
+msgid "A stub classfile will be produced with the specified name"
 msgstr ""
 
 #. type: Title ==

--- a/i18n/po/content/reference/data_structures/ja.po
+++ b/i18n/po/content/reference/data_structures/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2019-02-18 20:21+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -35,22 +35,6 @@ msgstr ""
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
 
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
-
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73 en/content/reference/namespaces.adoc:24
 #: en/content/reference/other_functions.adoc:41 en/content/reference/other_functions.adoc:65
@@ -72,6 +56,7 @@ msgstr "シンボル"
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:100 en/content/reference/data_structures.adoc:235
+#: en/content/guides/learn/hashed_colls.adoc:19
 #, no-wrap
 msgid "Sets"
 msgstr "セット"
@@ -108,11 +93,38 @@ msgid "They provide good hash values"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/data_structures.adoc:24
+msgid "In addition, the collections:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:25
+msgid "Are manipulated via interfaces."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:26
+msgid "Support sequencing"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:27
+msgid "Support persistent manipulation."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:28
+msgid "Support metadata"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:29
+msgid "Implement java.lang.Iterable"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/data_structures.adoc:30
-msgid ""
-"In addition, the collections: ** Are manipulated via interfaces.  ** Support sequencing ** Support persistent "
-"manipulation.  ** Support metadata ** Implement java.lang.Iterable ** Implement the non-optional (read-only) portion "
-"of java.util.Collection"
+msgid "Implement the non-optional (read-only) portion of java.util.Collection"
 msgstr ""
 
 #. type: Title ==
@@ -202,12 +214,17 @@ msgstr ""
 msgid "Numeric literals for BigInt and BigDecimal are specified using a postfix N and M respectively."
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/data_structures.adoc:69
+#. type: Table
+#: en/content/reference/data_structures.adoc:68
+#, no-wrap
 msgid ""
-"|=== | Example expression | Return value | `(== 1 1.0 1M)` | `true` | `(/ 2 3)` | `2/3` | `(/ 2.0 3)` | "
-"`0.6666666666666666` | `(map #(Math/abs %) (range -3 3))` | `(3 2 1 0 1 2)` | `(class 36786883868216818816N)` | "
-"`clojure.lang.BigInt` | `(class 3.14159265358M)` | `java.math.BigDecimal` |==="
+"| Example expression | Return value\n"
+"| `(== 1 1.0 1M)` | `true`\n"
+"| `(/ 2 3)` | `2/3`\n"
+"| `(/ 2.0 3)` | `0.6666666666666666`\n"
+"| `(map #(Math/abs %) (range -3 3))` | `(3 2 1 0 1 2)`\n"
+"| `(class 36786883868216818816N)` | `clojure.lang.BigInt`\n"
+"| `(class 3.14159265358M)` | `java.math.BigDecimal`\n"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/po/content/reference/datatypes/ja.po
+++ b/i18n/po/content/reference/datatypes/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
-"PO-Revision-Date: 2018-05-04 05:57+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 01:23+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/protocols.adoc:16 en/content/reference/datatypes.adoc:17
@@ -80,7 +64,7 @@ msgid "Basics"
 msgstr "基本"
 
 #. type: Plain text
-#: en/content/reference/special_forms.adoc:176 en/content/reference/datatypes.adoc:115 en/content/guides/faq.adoc:177
+#: en/content/reference/special_forms.adoc:182 en/content/reference/datatypes.adoc:115 en/content/guides/faq.adoc:184
 msgid "Example:"
 msgstr "例:"
 
@@ -155,16 +139,23 @@ msgid "because they generate a named class, it has an accessible constructor"
 msgstr "名前付きのクラスを生成するため、アクセス可能なコンストラクターを持つ"
 
 #. type: Plain text
-#: en/content/reference/datatypes.adoc:36
+#: en/content/reference/datatypes.adoc:34
+msgid "fields can have type hints, and can be primitive"
+msgstr "フィールドはプリミティブ型を含む型ヒントを持つことができる"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:35
 msgid ""
-"fields can have type hints, and can be primitive ** note that currently a type hint of a non-primitive type will not "
-"be used to constrain the field type nor the constructor arg, but will be used to optimize its use in the class "
-"methods ** constraining the field type and constructor arg is planned"
+"note that currently a type hint of a non-primitive type will not be used to constrain the field type nor the "
+"constructor arg, but will be used to optimize its use in the class methods"
 msgstr ""
-"フィールドはプリミティブ型を含む型ヒントを持つことができる\n"
-"** 注: 現在、非プリミティブな型ヒントはフィールドの型やコンストラクターの引数を制限するものではないが、クラスメソッド"
-"の利用時の最適化のために使用される\n"
-"** フィールドやコンストラクターの型の制限は計画されている"
+"注: 現在、非プリミティブな型ヒントはフィールドの型やコンストラクターの引数を制限するものではないが、クラスメソッドの利"
+"用時の最適化のために使用される"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:36
+msgid "constraining the field type and constructor arg is planned"
+msgstr "フィールドやコンストラクターの型の制限は計画されている"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:37
@@ -172,16 +163,24 @@ msgid "a deftype/defrecord can implement one or more protocols and/or interfaces
 msgstr "deftype/defrecordは1つ以上のプロトコルもしくはインターフェースを実装することができる"
 
 #. type: Plain text
-#: en/content/reference/datatypes.adoc:41
-msgid ""
-"deftype/defrecord can be written with a special reader syntax #my.thing[1 2 3] where: ** each element in the vector "
-"form is passed to the deftype/defrecord's constructor un-evaluated ** the deftype/defrecord name must be fully "
-"qualified ** only available in Clojure versions later than 1.3"
-msgstr ""
-"deftype/defrecordは特別なリーダーシンタックス #my.thing[1 2 3] で記述することができる:\n"
-"** ベクターの各要素がdeftype/defrecordのコンストラクターに評価されずに渡される\n"
-"** deftype/defrecordの名前は完全修飾されている必要がある\n"
-"** Clojureのバージョン1.3以降でのみ利用可能"
+#: en/content/reference/datatypes.adoc:38
+msgid "deftype/defrecord can be written with a special reader syntax #my.thing[1 2 3] where:"
+msgstr "deftype/defrecordは特別なリーダーシンタックス #my.thing[1 2 3] で記述することができる:"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:39
+msgid "each element in the vector form is passed to the deftype/defrecord's constructor un-evaluated"
+msgstr "ベクターの各要素がdeftype/defrecordのコンストラクターに評価されずに渡される"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:40
+msgid "the deftype/defrecord name must be fully qualified"
+msgstr "deftype/defrecordの名前は完全修飾されている必要がある"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:41 en/content/reference/datatypes.adoc:62
+msgid "only available in Clojure versions later than 1.3"
+msgstr "Clojureのバージョン1.3以降でのみ利用可能"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:42
@@ -207,19 +206,39 @@ msgid "deftype provides no functionality not specified by the user, other than a
 msgstr "deftypeはコンストラクター以外にはユーザーに明示されていないいかなる機能も提供しない"
 
 #. type: Plain text
+#: en/content/reference/datatypes.adoc:48
+msgid "defrecord provides a complete implementation of a persistent map, including:"
+msgstr "defrecordは以下を含む永続的なマップの完全な実装を提供する:"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:49
+msgid "value-based equality and hashCode"
+msgstr "値に基づく同値比較とhashCode"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:50
+msgid "metadata support"
+msgstr "メタデータのサポート"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:51
+msgid "associative support"
+msgstr "associativeのサポートト"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:52
+msgid "keyword accessors for fields"
+msgstr "フィールドのキーワードアクセサ"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:53
+msgid "extensible fields (you can assoc keys not supplied with the defrecord definition)"
+msgstr "拡張可能なフィールド(defrecordの定義にないフィールドのキーをassocすることができる)"
+
+#. type: Plain text
 #: en/content/reference/datatypes.adoc:54
-msgid ""
-"defrecord provides a complete implementation of a persistent map, including: ** value-based equality and hashCode ** "
-"metadata support ** associative support ** keyword accessors for fields ** extensible fields (you can assoc keys not "
-"supplied with the defrecord definition)  ** etc"
-msgstr ""
-"defrecordは以下を含む永続的なマップの完全な実装を提供する:\n"
-"** 値に基づく同値比較とhashCode\n"
-"** メタデータのサポート\n"
-"** associativeのサポート\n"
-"** フィールドのキーワードアクセサ\n"
-"** 拡張可能なフィールド(defrecordの定義にないフィールドのキーをassocすることができる)\n"
-"** など"
+msgid "etc"
+msgstr "など"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:55
@@ -227,21 +246,36 @@ msgid "deftype supports mutable fields, defrecord does not"
 msgstr "deftypeはミュータブルなフィールドをサポートするが、defrecordはサポートしない"
 
 #. type: Plain text
-#: en/content/reference/datatypes.adoc:62
+#: en/content/reference/datatypes.adoc:56
 msgid ""
 "defrecord supports an additional reader form of #my.record{:a 1, :b 2} taking a map that initializes a defrecord "
-"according to: ** the defrecord name must be fully qualified ** the elements in the map are un-evaluated ** existing "
-"defrecord fields take the keyed values ** defrecord fields without keyed values in the literal map are initialized to "
-"nil ** additional keyed values are allowed and added to the defrecord ** only available in Clojure versions later "
-"than 1.3"
-msgstr ""
-"defrecordは加えて初期値のマップを受け取る#my.record{:a 1, :b 2}のリーダーフォームをサポートする:\n"
-"** defrecord名は完全修飾されている必要がある\n"
-"** マップ内の要素は評価されない\n"
-"** 既存のdefrecordフィールドは対応するキーの値に初期化される\n"
-"** リテラルマップに対応するキーのないdefrecordフィールドはnilに初期化される\n"
-"** defrecordフィールド以外のキーは許容されており、defrecordに追加される\n"
-"** Clojureバージョン1.3以降で利用可能"
+"according to:"
+msgstr "defrecordは加えて初期値のマップを受け取る#my.record{:a 1, :b 2}のリーダーフォームをサポートする:"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:57
+msgid "the defrecord name must be fully qualified"
+msgstr "defrecord名は完全修飾されている必要がある"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:58
+msgid "the elements in the map are un-evaluated"
+msgstr "マップ内の要素は評価されない"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:59
+msgid "existing defrecord fields take the keyed values"
+msgstr "既存のdefrecordフィールドはキーに対応する値をとる"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:60
+msgid "defrecord fields without keyed values in the literal map are initialized to nil"
+msgstr "リテラルマップにキーに対応する値のないdefrecordフィールドはnilに初期化される"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:61
+msgid "additional keyed values are allowed and added to the defrecord"
+msgstr "追加のキーに対する値は許容されており、defrecordに追加される"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:63
@@ -330,41 +364,54 @@ msgstr ""
 "するための努力は一切していない。具体的には以下の意見を反映している:"
 
 #. type: Plain text
+#: en/content/reference/datatypes.adoc:79
+msgid "Concrete derivation is bad"
+msgstr "具象的な派生は悪手だ"
+
+#. type: Plain text
 #: en/content/reference/datatypes.adoc:80
-msgid "Concrete derivation is bad ** you cannot derive datatypes from concrete classes, only interfaces"
-msgstr ""
-"具象的な派生は悪手だ\n"
-"** 具象クラスからデータ型を派生させることはできず、インターフェースからのみ行える"
+msgid "you cannot derive datatypes from concrete classes, only interfaces"
+msgstr "具象クラスからデータ型を派生させることはできず、インターフェースからのみ行える"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:81
+msgid "You should always program to protocols or interfaces"
+msgstr "常にプロトコルもしくはインターフェースに対してプログラムするべきだ"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:82
-msgid ""
-"You should always program to protocols or interfaces ** datatypes cannot expose methods not in their protocols or "
-"interfaces"
-msgstr ""
-"常にプロトコルもしくはインターフェースに対してプログラムするべきだ\n"
-"** データ型はそのプロトコルもしくはインターフェースで定義されていないメソッドを公開することはできない"
+msgid "datatypes cannot expose methods not in their protocols or interfaces"
+msgstr "データ型はそのプロトコルもしくはインターフェースで定義されていないメソッドを公開することはできない"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:83
+msgid "Immutability should be the default"
+msgstr "イミュータブルがデフォルトであるべきだ"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:84
-msgid "Immutability should be the default ** and is the only option for records"
-msgstr ""
-"イミュータブルがデフォルトであるべきだ\n"
-"** レコードについては唯一の選択肢となっている"
+msgid "and is the only option for records"
+msgstr "レコードについては唯一の選択肢となっている"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:85
+msgid "Encapsulation of information is folly"
+msgstr "情報のカプセル化は愚かだ"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:86
-msgid "Encapsulation of information is folly ** fields are public, use protocols/interfaces to avoid dependencies"
-msgstr ""
-"情報のカプセル化は愚かだ\n"
-"** フィールドはパブリックであり、依存関係を避けるためにプロトコルもしくはインターフェースを利用する"
+msgid "fields are public, use protocols/interfaces to avoid dependencies"
+msgstr "フィールドはパブリックであり、依存関係を避けるためにプロトコルもしくはインターフェースを利用する"
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:87
+msgid "Tying polymorphism to inheritance is bad"
+msgstr "ポリモーフィズムと継承を結びつけることは悪手だ"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:88
-msgid "Tying polymorphism to inheritance is bad ** protocols free you from that"
-msgstr ""
-"ポリモーフィズムと継承を結びつけることは悪手だ\n"
-"** プロトコルを利用することでこれを避けることができる"
+msgid "protocols free you from that"
+msgstr "プロトコルを利用することでこれを避けることができる"
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:90

--- a/i18n/po/content/reference/deps_and_cli/ja.po
+++ b/i18n/po/content/reference/deps_and_cli/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-02 07:15+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,27 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/deps_and_cli.adoc:1 en/content/guides/faq.adoc:203
@@ -352,37 +331,130 @@ msgid "The tools rely on several directories and optionally on several environme
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:135
+#, fuzzy
+#| msgid "Installation on Windows"
+msgid "Installation directory"
+msgstr "Windowsへのインストール"
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:136
+#, fuzzy
+#| msgid "Creating Functions"
+msgid "Created during installation"
+msgstr "関数を作る"
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:137 en/content/reference/deps_and_cli.adoc:149
+#: en/content/reference/deps_and_cli.adoc:158
+msgid "Contents:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:138
+msgid "`bin/clojure` - main tool"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:139
+msgid "`bin/clj` - wrapper for interactive repl use (uses `rlwrap`)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:140
+msgid "`deps.edn` - install level deps.edn file, with some default deps (Clojure, etc) and provider config"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:141
+msgid "`example-deps.edn` - commented example that gets copied to `<config_dir>/deps.edn`"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:142
-msgid ""
-"Installation directory ** Created during installation ** Contents: *** `bin/clojure` - main tool *** `bin/clj` - "
-"wrapper for interactive repl use (uses `rlwrap`)  *** `deps.edn` - install level deps.edn file, with some default "
-"deps (Clojure, etc) and provider config *** `example-deps.edn` - commented example that gets copied to `<config_dir>/"
-"deps.edn` *** `libexec/clojure-tools-X.Y.Z.jar` - uberjar invoked by `clojure` to construct classpaths"
+msgid "`libexec/clojure-tools-X.Y.Z.jar` - uberjar invoked by `clojure` to construct classpaths"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:143
+msgid "Config directory"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:144
+msgid "Holds a deps.edn file that persists across tool upgrades and affects all projects"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:145
+msgid "Locations used in this order:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:146
+msgid "If `$CLJ_CONFIG` is set, then use `$CLJ_CONFIG` (explicit override)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:147
+msgid "If `$XDG_CONFIG_HOME` is set, then use `$XDG_CONFIG_HOME/clojure` (Freedesktop conventions)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:148
+msgid "Else use `$HOME/.clojure` (most common)"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:150
-msgid ""
-"Config directory ** Holds a deps.edn file that persists across tool upgrades and affects all projects ** Locations "
-"used in this order: *** If `$CLJ_CONFIG` is set, then use `$CLJ_CONFIG` (explicit override)  *** If `"
-"$XDG_CONFIG_HOME` is set, then use `$XDG_CONFIG_HOME/clojure` (Freedesktop conventions)  *** Else use `$HOME/."
-"clojure` (most common)  ** Contents: *** `deps.edn` - user deps file, defines default Clojure version and provider "
-"defaults"
+msgid "`deps.edn` - user deps file, defines default Clojure version and provider defaults"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:151
+msgid "Cache directory"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:152
+msgid "Lazily created when `clojure` is invoked without a local `deps.edn` file. Locations used in this order:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:153
+msgid "If `$CLJ_CACHE` is set, then use `$CLJ_CACHE` (explicit override)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:154
+msgid "If `$XDG_CACHE_HOME` is set, then use `$XDG_CACHE_HOME/clojure` (Freedesktop conventions)"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:155
-msgid ""
-"Cache directory ** Lazily created when `clojure` is invoked without a local `deps.edn` file. Locations used in this "
-"order: *** If `$CLJ_CACHE` is set, then use `$CLJ_CACHE` (explicit override)  *** If `$XDG_CACHE_HOME` is set, then "
-"use `$XDG_CACHE_HOME/clojure` (Freedesktop conventions)  *** Else use `config_dir/.cpcache` (most common)"
+msgid "Else use `config_dir/.cpcache` (most common)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:156
+msgid "Project directory"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:157
+#, fuzzy
+#| msgid "The clojure.main namespace"
+msgid "The current directory"
+msgstr "clojure.mainネームスペース"
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:159
+msgid "`deps.edn` - optional project deps"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:160
-msgid ""
-"Project directory ** The current directory ** Contents: *** `deps.edn` - optional project deps *** `.cpcache` - "
-"project cache directory, same as the user-level cache directory, created if there is a `deps.edn`"
+msgid "`.cpcache` - project cache directory, same as the user-level cache directory, created if there is a `deps.edn`"
 msgstr ""
 
 #. type: Title ===
@@ -450,16 +522,38 @@ msgid "Coordinates can take several forms depending on the coordinate type:"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:182
+msgid "Maven coordinate: `{:mvn/version \"1.2.3\"}`"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:183
-msgid "Maven coordinate: `{:mvn/version \"1.2.3\"}` ** Other optional keys: `:classifier`, `:extension`, `:exclusions`"
+msgid "Other optional keys: `:classifier`, `:extension`, `:exclusions`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:184
+msgid "Local project coordinate: `{:local/root \"/path/to/project\"}`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:185
+msgid "Optional key `:deps/manifest`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:186
+msgid "Specifies the project manifest type"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:187
+msgid "Default is to auto-detect the project type (such as `:deps`, `:lein`, `:pom`)"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:188
-msgid ""
-"Local project coordinate: `{:local/root \"/path/to/project\"}` ** Optional key `:deps/manifest` *** Specifies the "
-"project manifest type *** Default is to auto-detect the project type (such as `:deps`, `:lein`, `:pom`)  *** "
-"Currently only `:deps` is supported"
+msgid "Currently only `:deps` is supported"
 msgstr ""
 
 #. type: Plain text
@@ -468,12 +562,33 @@ msgid "Local jar: `{:local/root \"/path/to/file.jar\"}`"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:190
+msgid "Git coordinate: `{:git/url \"https://github.com/user/project.git\", :sha \"sha\", :tag \"tag\"}`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:191
+msgid "The `:git/url` can be one of the following:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:192
+msgid "https - secure anonymous access to public repos"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:193
+msgid "ssh or user@host form urls (including GitHub) - ssh-based access (see Git configuration section)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:194
+msgid "The `:sha` attribute should indicate the full commit sha"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:195
-msgid ""
-"Git coordinate: `{:git/url \"https://github.com/user/project.git\", :sha \"sha\", :tag \"tag\"}` ** The `:git/url` "
-"can be one of the following: *** https - secure anonymous access to public repos *** ssh or user@host form urls "
-"(including GitHub) - ssh-based access (see Git configuration section)  ** The `:sha` attribute should indicate the "
-"full commit sha ** The `:tag` attribute is optional but can be used to indicate the semantics of the sha"
+msgid "The `:tag` attribute is optional but can be used to indicate the semantics of the sha"
 msgstr ""
 
 #. type: delimited block -
@@ -515,7 +630,7 @@ msgid "{:paths [\"src\"]}\n"
 msgstr ""
 
 #. type: Title ==
-#: en/content/reference/deps_and_cli.adoc:216 en/content/reference/java_interop.adoc:271
+#: en/content/reference/deps_and_cli.adoc:216 en/content/reference/java_interop.adoc:275
 #, no-wrap
 msgid "Aliases"
 msgstr ""
@@ -527,42 +642,110 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:221
+msgid "-R - `resolve-deps` aliases are modifications applied during `resolve-deps`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:222 en/content/reference/deps_and_cli.adoc:228
+#: en/content/reference/deps_and_cli.adoc:233 en/content/reference/deps_and_cli.adoc:238
+msgid "Allowed keys in these aliases are:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:223
+msgid "`:extra-deps` - a deps map from lib to coordinate of deps to add to the deps"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:224
+msgid "`:override-deps` - a deps map from lib to coordinate of override versions to use"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:225
+msgid "`:default-deps` - a deps map from lib to coordinate of versions to use if none is found"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:226
-msgid ""
-"-R - `resolve-deps` aliases are modifications applied during `resolve-deps` ** Allowed keys in these aliases are: *** "
-"`:extra-deps` - a deps map from lib to coordinate of deps to add to the deps *** `:override-deps` - a deps map from "
-"lib to coordinate of override versions to use *** `:default-deps` - a deps map from lib to coordinate of versions to "
-"use if none is found ** If multiple -R alias maps are activated, all of these are merge-with merged"
+msgid "If multiple -R alias maps are activated, all of these are merge-with merged"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:227
+msgid "-C - `make-classpath` aliases are modifications applied during `make-classpath`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:229
+#, fuzzy
+#| msgid "`args` - sequential collection of args to pass to accept"
+msgid "`:extra-paths` - a collection of string paths to add to `:paths`"
+msgstr "`args` - acceptに渡す引数のシーケンシャルなコレクション"
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:230
+msgid "`:classpath-overrides` - a map of lib to string path to replace the location of the lib"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:231
-msgid ""
-"-C - `make-classpath` aliases are modifications applied during `make-classpath` ** Allowed keys in these aliases are: "
-"*** `:extra-paths` - a collection of string paths to add to `:paths` *** `:classpath-overrides` - a map of lib to "
-"string path to replace the location of the lib *** If multiple -C alias maps are activated, `:extra-paths` "
-"concatenate and `:classpath-overrides` merge-with merge"
+msgid "If multiple -C alias maps are activated, `:extra-paths` concatenate and `:classpath-overrides` merge-with merge"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:232
+msgid "-O - JVM option aliases"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:234
+msgid "`:jvm-opts` - a collection of string JVM options"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:235
+msgid "If multiple -O alias maps are activated, `:jvm-opts` concatenate"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:236
-msgid ""
-"-O - JVM option aliases ** Allowed keys in these aliases are: *** `:jvm-opts` - a collection of string JVM options ** "
-"If multiple -O alias maps are activated, `:jvm-opts` concatenate ** If -J JVM options are also specified on the "
-"command line, they are concatenated after the alias options"
+msgid "If -J JVM options are also specified on the command line, they are concatenated after the alias options"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:237
+#, fuzzy
+#| msgid "The clojure.main namespace"
+msgid "-M - clojure.main option aliases"
+msgstr "clojure.mainネームスペース"
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:239
+msgid "`:main-opts` - a collection of clojure.main options"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:240
+msgid "If multiple -M alias maps are activated, only the last one will be used"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:241
 msgid ""
-"-M - clojure.main option aliases ** Allowed keys in these aliases are: *** `:main-opts` - a collection of clojure."
-"main options ** If multiple -M alias maps are activated, only the last one will be used ** If command line clojure."
-"main arguments are supplied on the command line, they are concatenated after the last main alias map"
+"If command line clojure.main arguments are supplied on the command line, they are concatenated after the last main "
+"alias map"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:242
+msgid "-A - applies across all alias types"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:243
-msgid "-A - applies across all alias types ** These aliases support ALL alias keys above and all will be applied"
+msgid "These aliases support ALL alias keys above and all will be applied"
 msgstr ""
 
 #. type: Plain text
@@ -891,19 +1074,53 @@ msgid "The following process is used to construct the classpath for invoking clo
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:385
+msgid "Compute the deps map"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:386
+msgid "Read the deps.edn configuration file in the following locations:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:387
+msgid "Install directory (unless -Srepro)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:388
+msgid "Config directory (if it exists and unless -Srepro)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:389
+msgid "Current directory (if it exists)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:390
+msgid "-Sdeps data (if it exists)"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:391
-msgid ""
-"Compute the deps map ** Read the deps.edn configuration file in the following locations: *** Install directory "
-"(unless -Srepro)  *** Config directory (if it exists and unless -Srepro)  *** Current directory (if it exists)  *** -"
-"Sdeps data (if it exists)  ** Combine the deps.edn maps in that order with `merge-with merge` (except for :paths "
-"where last wins)"
+msgid "Combine the deps.edn maps in that order with `merge-with merge` (except for :paths where last wins)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:392
+msgid "Compute the resolve-deps args"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:393
+msgid "If `-R` specifies one or more aliases, find each alias in the deps map `:aliases`"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:394
-msgid ""
-"Compute the resolve-deps args ** If `-R` specifies one or more aliases, find each alias in the deps map `:aliases` ** "
-"`merge-with` `merge` the alias maps - the result is the resolve-args map"
+msgid "`merge-with` `merge` the alias maps - the result is the resolve-args map"
 msgstr ""
 
 #. type: Plain text
@@ -912,10 +1129,18 @@ msgid "Invoke `resolve-deps` with deps map and resolve-args map"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:396
+msgid "Compute the classpath-overrides map"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:397
+msgid "If `-C` specifies one or more aliases, find each alias in the deps map `:aliases`"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:398
-msgid ""
-"Compute the classpath-overrides map ** If `-C` specifies one or more aliases, find each alias in the deps map `:"
-"aliases` ** `merge` the classpath-override alias maps"
+msgid "`merge` the classpath-override alias maps"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/po/content/reference/java_interop/ja.po
+++ b/i18n/po/content/reference/java_interop/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/reference/metadata.adoc:23 en/content/reference/metadata.adoc:29 en/content/reference/libs.adoc:63

--- a/i18n/po/content/reference/lazy/ja.po
+++ b/i18n/po/content/reference/lazy/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,39 +17,23 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4 en/content/reference/metadata.adoc:4
-#: en/content/reference/evaluation.adoc:4 en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4 en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4 en/content/reference/other_libraries.adoc:4
-#: en/content/reference/data_structures.adoc:4 en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4 en/content/reference/lisps.adoc:4
-#: en/content/reference/lazy.adoc:4 en/content/reference/repl_and_main.adoc:4 en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/multimethods.adoc:4
-#: en/content/search.adoc:4 en/content/about/clojureclr.adoc:4 en/content/about/functional_programming.adoc:4
-#: en/content/about/lisp.adoc:4 en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4 en/content/about/rationale.adoc:4
-#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4 en/content/privacy.adoc:4
-#: en/content/community/swag.adoc:4 en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
-#: en/content/community/downloads_older.adoc:4 en/content/community/libraries.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4 en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/transients.adoc:4
+#: en/content/reference/compilation.adoc:4 en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4 en/content/reference/transducers.adoc:4
+#: en/content/reference/refs.adoc:4 en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4 en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4 en/content/reference/data_structures.adoc:4 en/content/reference/atoms.adoc:4
+#: en/content/reference/repl_and_main.adoc:4 en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4 en/content/community/downloads_older.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4 en/content/404.adoc:4
+#: en/content/privacy.adoc:4 en/content/search.adoc:4 en/content/about/spec.adoc:4
+#: en/content/about/concurrent_programming.adoc:4 en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4 en/content/about/features.adoc:4
+#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/special_forms.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/metadata.adoc:15 en/content/reference/reader.adoc:13 en/content/reference/transients.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_functions.adoc:17 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/java_interop.adoc:15 en/content/reference/data_structures.adoc:16
-#: en/content/reference/datatypes.adoc:16 en/content/reference/agents.adoc:16 en/content/reference/protocols.adoc:15
-#: en/content/reference/reducers.adoc:15 en/content/reference/lazy.adoc:12 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/transducers.adoc:15 en/content/reference/vars.adoc:16 en/content/reference/namespaces.adoc:15
-#: en/content/reference/libs.adoc:16 en/content/reference/multimethods.adoc:15
-#: en/content/about/functional_programming.adoc:15 en/content/about/dynamic.adoc:16 en/content/about/spec.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/reference/lazy.adoc:1
@@ -71,22 +55,52 @@ msgid "In working on streams a few things became evident:"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/lazy.adoc:18
+msgid "stream code is ugly and imperative"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/lazy.adoc:19
-msgid "stream code is ugly and imperative ** even when made safe, still ugly, stateful"
+msgid "even when made safe, still ugly, stateful"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:20
+msgid "streams support full laziness"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:21
-msgid "streams support full laziness ** this ends up being extremely nice"
+msgid "this ends up being extremely nice"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:22
+msgid ""
+"Integrating streams transparently (i.e. not having both map and map-stream) would require a change, to relax the "
+"contract of the core sequence functions (map, filter etc)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:23
+msgid ""
+"If I am going to do that, could I achieve the same full laziness while keeping the beautiful recursive style of "
+"Clojure?"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:24
+msgid "while being substantially compatible with existing code"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:25
+msgid "Yes!"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:26
-msgid ""
-"Integrating streams transparently (i.e. not having both map and map-stream) would require a change, to relax the "
-"contract of the core sequence functions (map, filter etc)  ** If I am going to do that, could I achieve the same full "
-"laziness while keeping the beautiful recursive style of Clojure? *** while being substantially compatible with "
-"existing code *** Yes! **** but - ideally some names should change"
+msgid "but - ideally some names should change"
 msgstr ""
 
 #. type: Title ===
@@ -111,11 +125,28 @@ msgid "A seq is like a logical cursor"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/lazy.adoc:33
+msgid "rest is fundamentally eager"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:34
+msgid "returns another seq or nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:35
+msgid "needs to determine if there is any more in order to determine if return value is nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:36
+msgid "lazy-cons can delay the calculation of first/rest, but not the determination if there is a rest"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/lazy.adoc:37
-msgid ""
-"rest is fundamentally eager ** returns another seq or nil ** needs to determine if there is any more in order to "
-"determine if return value is nil ** lazy-cons can delay the calculation of first/rest, but not the determination if "
-"there is a rest *** determining that often requires 'pulling' on an inner seq, reducing effective laziness"
+msgid "determining that often requires 'pulling' on an inner seq, reducing effective laziness"
 msgstr ""
 
 #. type: Plain text
@@ -137,49 +168,131 @@ msgid "Enhancing the seq model - a third operation on seqs - 'next'"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/lazy.adoc:44
+msgid "_**Changed:**_ (*rest* aseq) - returns a possibly empty seq, _never nil_"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:45 en/content/reference/lazy.adoc:58 en/content/reference/lazy.adoc:63
+msgid "calls seq on arg if not already a seq"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:46
+msgid "the returned seq may be empty"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:47
+msgid "will print (), but not a single sentinel object"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:48
+#, fuzzy
+#| msgid "Returns `nil`"
+msgid "never returns nil"
+msgstr "`nil` を返す"
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:49
+msgid "currently not enforced on 3rd-party seqs"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/lazy.adoc:50
-msgid ""
-"_**Changed:**_ (*rest* aseq) - returns a possibly empty seq, _never nil_ ** calls seq on arg if not already a seq ** "
-"the returned seq may be empty *** will print (), but not a single sentinel object ** never returns nil *** currently "
-"not enforced on 3rd-party seqs ** a (possibly) delayed path to the remaining items, if any"
+msgid "a (possibly) delayed path to the remaining items, if any"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:51
+msgid "_**Changed**_: seqs can be empty"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:52
-msgid "_**Changed**_: seqs can be empty ** always an ISeq"
+msgid "always an ISeq"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:56
-msgid ""
-"_**Changed**_: the *seq* function - no longer an identity for ISeqs ** still returns either a seq or nil ** (seq "
-"aseq) -> ___**no longer an identity, if aseq empty returns nil**___ ** still works on nil"
+#: en/content/reference/lazy.adoc:53
+msgid "_**Changed**_: the *seq* function - no longer an identity for ISeqs"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:60
-msgid ""
-"the *first* function doesn't change ** calls seq on arg if not already a seq ** returns first item ** still works on "
-"nil"
+#: en/content/reference/lazy.adoc:54
+msgid "still returns either a seq or nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:55
+msgid "(seq aseq) -> ___**no longer an identity, if aseq empty returns nil**___"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:56 en/content/reference/lazy.adoc:60
+msgid "still works on nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:57
+msgid "the *first* function doesn't change"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:59
+msgid "returns first item"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:61
+msgid "_**New**:_ the *next* function does what *rest* used to do"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:62
+msgid "returns the next seq, if any, else nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:64
+msgid "(next aseq) === (seq (rest aseq))"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:65
-msgid ""
-"_**New**:_ the *next* function does what *rest* used to do ** returns the next seq, if any, else nil ** calls seq on "
-"arg if not already a seq ** (next aseq) === (seq (rest aseq))  ** works on nil"
+msgid "works on nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:66
+msgid "_**Changed**_: seq?"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:67
-msgid "_**Changed**_: seq? ** (seq? ()) -> true"
+#, fuzzy
+#| msgid ""
+#| "(isa? 42 42)\n"
+#| "-> true\n"
+msgid "(seq? ()) -> true"
+msgstr ""
+"(isa? 42 42)\n"
+"-> true\n"
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:68
+msgid "_**Changed:**_ Sequence fns (map, filter etc) return seqs, but not nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:69
+msgid "You'll need to call seq on their return value in order to get a seq/nil"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:70
-msgid ""
-"_**Changed:**_ Sequence fns (map, filter etc) return seqs, but not nil ** You'll need to call seq on their return "
-"value in order to get a seq/nil *** seq also serves as test for end, already idiomatic"
+msgid "seq also serves as test for end, already idiomatic"
 msgstr ""
 
 #. type: delimited block -
@@ -191,12 +304,18 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/lazy.adoc:77
+msgid "allows full laziness"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:78
+msgid "doesn't support nil punning"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/lazy.adoc:79
-#, no-wrap
-msgid ""
-"** allows full laziness\n"
-"** doesn't support nil punning\n"
-"*** since sequence fns no longer return seq/nil\n"
+msgid "since sequence fns no longer return seq/nil"
 msgstr ""
 
 #. type: Title ===
@@ -206,24 +325,79 @@ msgid "Recipe - How to write lazy sequence functions in new model"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:93
+#: en/content/reference/lazy.adoc:83
+msgid "Goodbye lazy-cons, hello lazy-seq"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:84
+msgid "lazy-cons is gone"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:85
+msgid "new laziness macro - _**lazy-seq**_"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:86
+msgid "takes a body that yields a seq, nil or anything seq-able"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:87
+msgid "returns a logical collection that implements seq by calling the body"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:88
+msgid "invokes the body only the first time seq is called on it, caches result"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:89
+msgid "will call seq on the body's return value if not already a seq or nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:90
 msgid ""
-"Goodbye lazy-cons, hello lazy-seq ** lazy-cons is gone ** new laziness macro - _**lazy-seq**_ *** takes a body that "
-"yields a seq, nil or anything seq-able *** returns a logical collection that implements seq by calling the body **** "
-"invokes the body only the first time seq is called on it, caches result **** will call seq on the body's return value "
-"if not already a seq or nil ** The net effect is the creation of a virtual collection that does no work until seq is "
-"called upon it - fully delayed ** Supports all collection ops ** Can be empty - e.g. calling seq on it can return nil "
-"*** when empty will print as ()"
+"The net effect is the creation of a virtual collection that does no work until seq is called upon it - fully delayed"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:91
+msgid "Supports all collection ops"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:92
+msgid "Can be empty - e.g. calling seq on it can return nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:93
+msgid "when empty will print as ()"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:94
+msgid "lazy-seq goes at top level of lazy sequence function"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:95
-msgid "lazy-seq goes at top level of lazy sequence function ** instead of nested lazy-cons"
+msgid "instead of nested lazy-cons"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:96
+msgid "inside, use a normal cons call"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:97
-msgid "inside, use a normal cons call ** won't be created until needed"
+msgid "won't be created until needed"
 msgstr ""
 
 #. type: Plain text
@@ -324,13 +498,41 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:145
+#: en/content/reference/lazy.adoc:139
 msgid ""
 "Audit your code for nil-punning. The lazy branch has supports compilation in a debug mode that asserts if you try to "
 "test the truth value of a lazy sequence in a conditional, and will throw an exception if you do. Just build clojure "
-"like so: ** ant -Dclojure.assert-if-lazy-seq=true ** Then, nil puns like the following will throw exceptions: *** "
-"(when (filter neg? [1 2]) :all-pos)  *** (not (concat))  *** (if (rest (seq [])) 1 2)  ** In all cases you can fix a "
-"nil pun by wrapping the sequence with a seq call:"
+"like so:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:140
+msgid "ant -Dclojure.assert-if-lazy-seq=true"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:141
+msgid "Then, nil puns like the following will throw exceptions:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:142
+msgid "(when (filter neg? [1 2]) :all-pos)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:143
+msgid "(not (concat))"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:144
+msgid "(if (rest (seq [])) 1 2)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:145
+msgid "In all cases you can fix a nil pun by wrapping the sequence with a seq call:"
 msgstr ""
 
 #. type: delimited block -
@@ -343,8 +545,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:152
-#, no-wrap
-msgid "** After you are done, rebuild without the flag, as it will slow things down.\n"
+msgid "After you are done, rebuild without the flag, as it will slow things down."
 msgstr ""
 
 #. type: Title ===

--- a/i18n/po/content/reference/libs/ja.po
+++ b/i18n/po/content/reference/libs/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
-"PO-Revision-Date: 2016-07-11 18:19+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 01:44+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/reference/metadata.adoc:23 en/content/reference/metadata.adoc:29 en/content/reference/libs.adoc:63
@@ -95,29 +79,46 @@ msgid "A lib name is a symbol that will typically contain two or more parts sepa
 msgstr "libの名前は通常ふたつ以上のピリオドで区切られたシンボルである。"
 
 #. type: Plain text
+#: en/content/reference/libs.adoc:25
+msgid "A lib's container is a Java resource whose classpath-relative path is derived from the lib name:"
+msgstr "libはJavaのリソースとして、libの名前から導出されたクラスパスに対して相対的なパスに格納される:"
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:26
+msgid "The path is a string"
+msgstr "パスは文字列"
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:27
+msgid "Periods in the lib name are replaced by slashes in the path"
+msgstr "lib名のピリオドはパスではスラッシュで置換される"
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:28
+msgid "Hyphens in the lib name are replaced by underscores in the path"
+msgstr "lib名のハイフンはパスではアンダースコアで置換される"
+
+#. type: Plain text
 #: en/content/reference/libs.adoc:29
-msgid ""
-"A lib's container is a Java resource whose classpath-relative path is derived from the lib name: ** The path is a "
-"string ** Periods in the lib name are replaced by slashes in the path ** Hyphens in the lib name are replaced by "
-"underscores in the path ** The path may end with \".class\", \".clj\", or \".cljc\" (see <<libs#order,Lib load "
-"order>> below)"
+msgid "The path may end with \".class\", \".clj\", or \".cljc\" (see <<libs#order,Lib load order>> below)"
 msgstr ""
-"lib は Java のリソースとして、 lib の名前から導出されたクラスパスに対して相対的なパスに格納される:\n"
-"** パスは文字列\n"
-"** lib名のピリオドはパスではスラッシュで置換される\n"
-"** lib名のハイフンはパスではアンダースコアで置換される\n"
-"** パスの拡張子には \".class\"、 \".clj\"、 もしくは \".cljc\" を使用することが出来る。(以下の <<libs#order,Lib load "
-"order>> を参照)"
+"パスの拡張子には\".class\"、 \".clj\"、 もしくは \".cljc\"を使用することができる(以下の <<libs#order,Lib load order>> "
+"を参照)"
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:30
+msgid "A lib begins with an \"ns\" form that"
+msgstr "libは以下を行う\"ns\"フォームで始まる:"
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:31
+msgid "creates the Clojure namespace that shares its name, and"
+msgstr "libと同じ名前のClojureネームスペースを作成する"
 
 #. type: Plain text
 #: en/content/reference/libs.adoc:32
-msgid ""
-"A lib begins with an \"ns\" form that ** creates the Clojure namespace that shares its name, and ** declares its "
-"dependencies on Java classes, Clojure's core facilities, and/or other libs,"
-msgstr ""
-"libは以下を行う \"ns\" フォームで始まる:\n"
-"** libと同じ名前のClojureネームスペースの作成\n"
-"** Javaのクラス、Clojureのコア機構、他のlib等に対する依存関係の宣言"
+msgid "declares its dependencies on Java classes, Clojure's core facilities, and/or other libs,"
+msgstr "Javaのクラス、Clojureのコア機構、他のlib等に対する依存関係を宣言する"
 
 #. type: Plain text
 #: en/content/reference/libs.adoc:34
@@ -125,8 +126,8 @@ msgid ""
 "Clojure ensures that if the call to \"ns\" completes without throwing an exception, the declared dependencies have "
 "been satisfied and the capabilities they provide are available."
 msgstr ""
-"Clojureは \"ns\" に対する呼び出しが例外無しで完了した場合、宣言された依存関係は満たされており、それらが提供する機能は"
-"使用可能であることを保証する。"
+"Clojureは\"ns\"に対する呼び出しが例外なしで完了した場合、宣言された依存関係は満たされており、それらが提供する機能は使"
+"用可能であることを保証する。"
 
 #. type: Title ==
 #: en/content/reference/libs.adoc:35

--- a/i18n/po/content/reference/lisps/ja.po
+++ b/i18n/po/content/reference/lisps/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
-"PO-Revision-Date: 2019-05-17 15:29+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 01:45+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -17,21 +17,21 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4 en/content/reference/metadata.adoc:4
-#: en/content/reference/evaluation.adoc:4 en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4 en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4 en/content/reference/other_libraries.adoc:4
-#: en/content/reference/data_structures.adoc:4 en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4 en/content/reference/lisps.adoc:4
-#: en/content/reference/lazy.adoc:4 en/content/reference/repl_and_main.adoc:4 en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/multimethods.adoc:4
-#: en/content/search.adoc:4 en/content/about/clojureclr.adoc:4 en/content/about/functional_programming.adoc:4
-#: en/content/about/lisp.adoc:4 en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4 en/content/about/rationale.adoc:4
-#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4 en/content/privacy.adoc:4
-#: en/content/community/swag.adoc:4 en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
-#: en/content/community/downloads_older.adoc:4 en/content/community/libraries.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4 en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/transients.adoc:4
+#: en/content/reference/compilation.adoc:4 en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4 en/content/reference/transducers.adoc:4
+#: en/content/reference/refs.adoc:4 en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4 en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4 en/content/reference/data_structures.adoc:4 en/content/reference/atoms.adoc:4
+#: en/content/reference/repl_and_main.adoc:4 en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4 en/content/community/downloads_older.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4 en/content/404.adoc:4
+#: en/content/privacy.adoc:4 en/content/search.adoc:4 en/content/about/spec.adoc:4
+#: en/content/about/concurrent_programming.adoc:4 en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4 en/content/about/features.adoc:4
+#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
 
@@ -42,112 +42,112 @@ msgid "Differences with other Lisps"
 msgstr "他のLispとの違い"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:14
+#: en/content/reference/lisps.adoc:16
 msgid "This information is provided for programmers familiar with Common Lisp or Scheme."
 msgstr "この情報はCommon LispやSchemeを知っているプログラマーのために提供されている。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:16
+#: en/content/reference/lisps.adoc:18
 msgid "Clojure is case sensitive"
 msgstr "Clojureは大文字と小文字の違いを気にする"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:17
+#: en/content/reference/lisps.adoc:19
 msgid "Clojure is a Lisp-1"
 msgstr "ClojureはLisp-1である"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:18
+#: en/content/reference/lisps.adoc:20
 msgid "() is not the same as nil"
 msgstr "()はnilとは異なる"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:19
+#: en/content/reference/lisps.adoc:21
 msgid "The reader is side-effect free"
 msgstr "readerは副作用を起こさない"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:20
+#: en/content/reference/lisps.adoc:22
 msgid "Keywords are not Symbols"
 msgstr "キーワードはシンボルではない"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:21
+#: en/content/reference/lisps.adoc:23
 msgid "Symbols are not storage locations (see Var)"
 msgstr "シンボルはストレージではない (Varを参照)"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:22
+#: en/content/reference/lisps.adoc:24
 msgid "_**nil**_ is not a Symbol"
 msgstr "_**nil**_ はシンボルではない"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:23
+#: en/content/reference/lisps.adoc:25
 msgid "t is not syntax, use _**true**_"
 msgstr "t はシンタックスに含まれない。 _**true**_ を使用する"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:24
+#: en/content/reference/lisps.adoc:26
 msgid "The read table is currently not accessible to user programs"
 msgstr "現在、ユーザープログラムがリードテーブルにアクセスすることはできない"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:25
+#: en/content/reference/lisps.adoc:27
 msgid "_**let**_ binds sequentially"
 msgstr "_**let**_ は逐次的に束縛を行う"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:26
+#: en/content/reference/lisps.adoc:28
 msgid "_**do**_ is not a looping construct"
 msgstr "_**do**_ はループ構造ではない"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:27
+#: en/content/reference/lisps.adoc:29
 msgid "There is no tail-call optimization, use _**recur**_."
 msgstr "末尾呼び出し最適化はない。 _**recur**_ を使用する。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:28
+#: en/content/reference/lisps.adoc:30
 msgid "syntax-quote does symbol resolution, so `x is not the same as 'x."
 msgstr "シンタックスクォートはシンボルの解決を行うため、 `x は 'x と異なる。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:29
+#: en/content/reference/lisps.adoc:31
 msgid "` has auto-gensyms."
 msgstr "` は自動的にgensymを行う。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:30
+#: en/content/reference/lisps.adoc:32
 msgid "~ is unquote ',' is whitespace"
 msgstr "~ はアンクォートで、 ',' は空白である"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:31
+#: en/content/reference/lisps.adoc:33
 msgid "There is reader syntax for maps, vectors, and sets"
 msgstr "マップ、ベクター、セットに対してリーダーのシンタックスが定義されている"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:32
+#: en/content/reference/lisps.adoc:34
 msgid "_**cons**_, _**first**_ and _**rest**_ manipulate sequence abstractions, not concrete cons cells"
 msgstr "_**cons**_, _**first**_ 及び _**rest**_ は具体的なコンスセルに対してではなく、シーケンス抽象を操作する。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:33
+#: en/content/reference/lisps.adoc:35
 msgid "Most data structures are immutable"
 msgstr "ほとんどのデータ構造はイミュータブルである。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:34
+#: en/content/reference/lisps.adoc:36
 msgid "lambda is _**fn**_, and supports overloading by arity"
 msgstr "ラムダは _**fn**_ であり、アリティによるオーバーロードをサポートしている。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:35
+#: en/content/reference/lisps.adoc:37
 msgid "_**pass:[=]**_ is the equality predicate"
 msgstr "_**pass:[=]**_ は等価性を示す述語である"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:36
+#: en/content/reference/lisps.adoc:38
 msgid ""
 "Global Vars can be dynamically rebound (if declared dynamic) without interfering with lexical local bindings. No "
 "special declarations are necessary to distinguish between dynamic and lexical bindings. Since Clojure is a Lisp-1, "
@@ -158,7 +158,7 @@ msgstr ""
 "ルな関数は動的に再束縛することができる。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:37
+#: en/content/reference/lisps.adoc:39
 msgid ""
 "No letrec, labels or flet - use (fn name [args]...) for self-reference, https://clojure.github.io/clojure/clojure."
 "core-api.html#clojure.core/letfn[letfn] for mutual reference."
@@ -167,7 +167,7 @@ msgstr ""
 "io/clojure/clojure.core-api.html#clojure.core/letfn[letfn] を使用する。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:38
+#: en/content/reference/lisps.adoc:40
 msgid ""
 "In Clojure _**nil**_ means 'nothing'. It signifies the absence of a value, of any type, and is not specific to lists "
 "or sequences."
@@ -176,17 +176,17 @@ msgstr ""
 "はない。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:39
+#: en/content/reference/lisps.adoc:41
 msgid "Empty collections are distinct from _**nil**_. Clojure does not equate _**nil**_ and '()."
 msgstr "空のコレクションは _**nil**_ とは明確に異なる。Clojureは _**nil**_ と '() を同値として扱わない。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:40
+#: en/content/reference/lisps.adoc:42
 msgid "_**false**_ means one of the two possible boolean values, the other being _**true**_"
 msgstr "_**false**_ はboolean型でとりうる２つの値のうちのひとつを示し、もうひとつの値は _**true**_ である。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:41
+#: en/content/reference/lisps.adoc:43
 msgid ""
 "There is more to collections than lists. You can have instances of empty collections, some of which have literal "
 "support ([], {}, and ()). Thus there can be no sentinel empty collection value."
@@ -195,12 +195,12 @@ msgstr ""
 "いる ([]、 {}、 及び ())。よって、空のコレクションを示すセンチネルな値は存在しない。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:42
+#: en/content/reference/lisps.adoc:44
 msgid "Coming from Scheme, _**nil**_ may map most closely to your notion of #f."
 msgstr "Schemeから来た場合、 _**nil**_ は#fの概念に最も似ているかもしれない。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:43
+#: en/content/reference/lisps.adoc:45
 msgid ""
 "A big difference in Clojure, is sequences. Sequences are not specific collections, esp. they are not necessarily "
 "concrete lists. When you ask an empty collection for a sequence of its elements (by calling *seq*) it returns "
@@ -215,7 +215,7 @@ msgstr ""
 "_lazy_ な(遅延評価される)ものにすることが可能になる。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:44
+#: en/content/reference/lisps.adoc:46
 msgid ""
 "Some of the sequence functions correspond to functions from Scheme and CL that there manipulated only pairs/conses "
 "('lists') and returned sentinel values ('() and nil) that represented 'empty' lists. The Clojure return values differ "
@@ -230,7 +230,7 @@ msgstr ""
 "ていない。"
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:45
+#: en/content/reference/lisps.adoc:47
 msgid ""
 "It helps to distinguish collections/data-structures and seqs/iteration. In both CL and Scheme they are conflated, in "
 "Clojure they are separate."
@@ -238,11 +238,10 @@ msgstr ""
 "コレクション/データ構造とseq/iterationを区別することは有用だ。CLとSchemeではどちらもそれらが入り混じっているが、"
 "Clojureでは区別されている。"
 
-#. type: Plain text
-#: en/content/reference/lisps.adoc:59
+#. type: Table
+#: en/content/reference/lisps.adoc:61
 #, no-wrap
 msgid ""
-"|===\n"
 "|   | Clojure | Common Lisp | Scheme | Java |\n"
 "| Has nil? | nil - means 'nothing' | nil - means false or empty list | - | null |\n"
 "| Has true? | true | - | #t | true (primitive) |\n"
@@ -254,9 +253,7 @@ msgid ""
 "| Host null: | nil | NA | NA | NA |\n"
 "| Host true: | true (boxed) | NA | NA | NA |\n"
 "| Host false: | false (boxed) | NA | NA | NA |\n"
-"|===\n"
 msgstr ""
-"|===\n"
 "|   | Clojure | Common Lisp | Scheme | Java |\n"
 "| nil があるか | nil - 「無」を意味する | nil - falseまたは空リストを意味する | - | null |\n"
 "| true があるか | true | - | #t | true (プリミティヴ) |\n"
@@ -268,4 +265,3 @@ msgstr ""
 "| ホスト環境の null: | nil | NA | NA | NA |\n"
 "| ホスト環境の true: | true (boxed) | NA | NA | NA |\n"
 "| ホスト環境の false: | false (boxed) | NA | NA | NA |\n"
-"|===\n"

--- a/i18n/po/content/reference/macros/ja.po
+++ b/i18n/po/content/reference/macros/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/macros.adoc:1 en/content/guides/spec.adoc:782 en/content/guides/destructuring.adoc:522

--- a/i18n/po/content/reference/metadata/ja.po
+++ b/i18n/po/content/reference/metadata/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -40,22 +40,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/reference/metadata.adoc:17
@@ -127,23 +111,39 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/metadata.adoc:38
+msgid "`^{:doc \"How obj works!\"} obj` - Sets the metadata of obj to the provided map."
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/metadata.adoc:39
-msgid ""
-"`^{:doc \"How obj works!\"} obj` - Sets the metadata of obj to the provided map.  ** Equivalent to `(with-meta obj {:"
-"doc \"How obj works!\"})`"
+msgid "Equivalent to `(with-meta obj {:doc \"How obj works!\"})`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/metadata.adoc:40
+msgid "`^:dynamic obj` - Sets the given keyword to true in the object's metadata."
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/metadata.adoc:41
-msgid ""
-"`^:dynamic obj` - Sets the given keyword to true in the object's metadata.  ** Equivalent to `^{:dynamic true} obj`"
+msgid "Equivalent to `^{:dynamic true} obj`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/metadata.adoc:42
+msgid "`^String obj` - Sets the value of :tag key in the object's metadata."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/metadata.adoc:43
+msgid "Equivalent to `^{:tag java.lang.String} obj`"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/metadata.adoc:44
 msgid ""
-"`^String obj` - Sets the value of :tag key in the object's metadata.  ** Equivalent to `^{:tag java.lang.String} obj` "
-"** Used to hint an objects type to the Clojure compiler. See <<java_interop#typehints,Java Interop: Type Hints>> for "
+"Used to hint an objects type to the Clojure compiler. See <<java_interop#typehints,Java Interop: Type Hints>> for "
 "more information and a complete list of special type hints."
 msgstr ""
 

--- a/i18n/po/content/reference/multimethods/ja.po
+++ b/i18n/po/content/reference/multimethods/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-06-01 09:26+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-05-04 06:22+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/reference/multimethods.adoc:1

--- a/i18n/po/content/reference/namespaces/ja.po
+++ b/i18n/po/content/reference/namespaces/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-10-21 09:59+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -35,22 +35,6 @@ msgstr ""
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
 
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
-
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73 en/content/reference/namespaces.adoc:24
 #: en/content/reference/other_functions.adoc:41 en/content/reference/other_functions.adoc:65
@@ -65,7 +49,7 @@ msgid "Related functions"
 msgstr "関連する関数"
 
 #. type: Plain text
-#: en/content/reference/namespaces.adoc:1 en/content/guides/reader_conditionals.adoc:87 en/content/guides/faq.adoc:126
+#: en/content/reference/namespaces.adoc:1 en/content/guides/reader_conditionals.adoc:87 en/content/guides/faq.adoc:133
 #: en/content/news/2011/07/22/introducing-clojurescript.adoc:28
 #, no-wrap
 msgid "Namespaces"

--- a/i18n/po/content/reference/other_functions/ja.po
+++ b/i18n/po/content/reference/other_functions/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,27 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73 en/content/reference/namespaces.adoc:24
@@ -96,16 +75,17 @@ msgstr ""
 msgid "Creating functions"
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/other_functions.adoc:35
+#. type: Table
+#: en/content/reference/other_functions.adoc:34
+#, no-wrap
 msgid ""
-"|=== | Function | Example expression | Return value | | <<special_forms#fn#,fn>> | `(map (fn [x] (+ 2 x)) [1 2 3])` | "
-"`(3 4 5)` | | pass:[#()] <<reader#,reader>> macro | `(map #(+ 2 %) [1 2 3])` | `(3 4 5)` | | https://clojure.github."
-"io/clojure/clojure.core-api.html#clojure.core/partial[partial] | `(map (partial + 2) [1 2 3])` | `(3 4 5)` | | "
-"https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/comp[comp] | `(map (comp - *) [2 4 6] [1 2 3])` "
-"| `(-2 -8 -18)` | | https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/complement[complement] | "
-"`(map (complement zero?) [3 2 1 0])` | `(true true true false)` | | https://clojure.github.io/clojure/clojure.core-"
-"api.html#clojure.core/constantly[constantly] | `(map (constantly 9) [1 2 3])` | `(9 9 9)` | |==="
+"| Function | Example expression | Return value |\n"
+"| <<special_forms#fn#,fn>> | `(map (fn [x] (+ 2 x)) [1 2 3])` | `(3 4 5)` |\n"
+"| pass:[#()] <<reader#,reader>> macro | `(map #(+ 2 %) [1 2 3])` | `(3 4 5)` |\n"
+"| https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/partial[partial] | `(map (partial + 2) [1 2 3])` | `(3 4 5)` |\n"
+"| https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/comp[comp] | `(map (comp - *) [2 4 6] [1 2 3])` | `(-2 -8 -18)` |\n"
+"| https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/complement[complement] | `(map (complement zero?) [3 2 1 0])` | `(true true true false)` |\n"
+"| https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/constantly[constantly] | `(map (constantly 9) [1 2 3])` | `(9 9 9)` |\n"
 msgstr ""
 
 #. type: Title ===

--- a/i18n/po/content/reference/other_libraries/ja.po
+++ b/i18n/po/content/reference/other_libraries/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2017-03-09 16:39+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -17,39 +17,23 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4 en/content/reference/metadata.adoc:4
-#: en/content/reference/evaluation.adoc:4 en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4 en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4 en/content/reference/other_libraries.adoc:4
-#: en/content/reference/data_structures.adoc:4 en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4 en/content/reference/lisps.adoc:4
-#: en/content/reference/lazy.adoc:4 en/content/reference/repl_and_main.adoc:4 en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/multimethods.adoc:4
-#: en/content/search.adoc:4 en/content/about/clojureclr.adoc:4 en/content/about/functional_programming.adoc:4
-#: en/content/about/lisp.adoc:4 en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4 en/content/about/rationale.adoc:4
-#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4 en/content/privacy.adoc:4
-#: en/content/community/swag.adoc:4 en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
-#: en/content/community/downloads_older.adoc:4 en/content/community/libraries.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4 en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/transients.adoc:4
+#: en/content/reference/compilation.adoc:4 en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4 en/content/reference/transducers.adoc:4
+#: en/content/reference/refs.adoc:4 en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4 en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4 en/content/reference/data_structures.adoc:4 en/content/reference/atoms.adoc:4
+#: en/content/reference/repl_and_main.adoc:4 en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4 en/content/community/downloads_older.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4 en/content/404.adoc:4
+#: en/content/privacy.adoc:4 en/content/search.adoc:4 en/content/about/spec.adoc:4
+#: en/content/about/concurrent_programming.adoc:4 en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4 en/content/about/features.adoc:4
+#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/special_forms.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/metadata.adoc:15 en/content/reference/reader.adoc:13 en/content/reference/transients.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_functions.adoc:17 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/java_interop.adoc:15 en/content/reference/data_structures.adoc:16
-#: en/content/reference/datatypes.adoc:16 en/content/reference/agents.adoc:16 en/content/reference/protocols.adoc:15
-#: en/content/reference/reducers.adoc:15 en/content/reference/lazy.adoc:12 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/transducers.adoc:15 en/content/reference/vars.adoc:16 en/content/reference/namespaces.adoc:15
-#: en/content/reference/libs.adoc:16 en/content/reference/multimethods.adoc:15
-#: en/content/about/functional_programming.adoc:15 en/content/about/dynamic.adoc:16 en/content/about/spec.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/reference/other_libraries.adoc:1

--- a/i18n/po/content/reference/protocols/ja.po
+++ b/i18n/po/content/reference/protocols/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-03-31 17:25+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/reference/protocols.adoc:1
@@ -90,25 +74,49 @@ msgid "Provide a high-performance, dynamic polymorphism construct as an alternat
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/protocols.adoc:24
+msgid "Support the best parts of interfaces"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:25
+#, fuzzy
+#| msgid "Informational vs implementational"
+msgid "specification only, no implementation"
+msgstr "情報的 vs 実装的"
+
+#. type: Plain text
 #: en/content/reference/protocols.adoc:26
+msgid "a single type can implement multiple protocols"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:27
+msgid "While avoiding some of the drawbacks"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:28
 msgid ""
-"Support the best parts of interfaces ** specification only, no implementation ** a single type can implement multiple "
-"protocols"
+"Which interfaces are implemented is a design-time choice of the type author, cannot be extended later (although "
+"interface injection might eventually address this)"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/protocols.adoc:29
+msgid "implementing an interface creates an isa/instanceof type relationship and hierarchy"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:30
 msgid ""
-"While avoiding some of the drawbacks ** Which interfaces are implemented is a design-time choice of the type author, "
-"cannot be extended later (although interface injection might eventually address this)  ** implementing an interface "
-"creates an isa/instanceof type relationship and hierarchy"
+"Avoid the 'expression problem' by allowing independent extension of the set of types, protocols, and implementations "
+"of protocols on types, by different parties"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/protocols.adoc:31
-msgid ""
-"Avoid the 'expression problem' by allowing independent extension of the set of types, protocols, and implementations "
-"of protocols on types, by different parties ** do so without wrappers/adapters"
+msgid "do so without wrappers/adapters"
 msgstr ""
 
 #. type: Plain text
@@ -156,10 +164,13 @@ msgid "Docs can be specified for the protocol and the functions"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/protocols.adoc:51
+msgid "The above yields a set of polymorphic functions and a protocol object"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/protocols.adoc:52
-msgid ""
-"The above yields a set of polymorphic functions and a protocol object ** all are namespace-qualified by the namespace "
-"enclosing the definition"
+msgid "all are namespace-qualified by the namespace enclosing the definition"
 msgstr ""
 
 #. type: Plain text
@@ -282,19 +293,40 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/protocols.adoc:104
+msgid "Function maps are maps of the keywordized method names to ordinary fns"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/protocols.adoc:105
-msgid ""
-"Function maps are maps of the keywordized method names to ordinary fns ** this facilitates easy reuse of existing fns "
-"and maps, for code reuse/mixins without derivation or composition"
+msgid "this facilitates easy reuse of existing fns and maps, for code reuse/mixins without derivation or composition"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:106
+#, fuzzy
+#| msgid "a deftype/defrecord can implement one or more protocols and/or interfaces"
+msgid "You can implement a protocol on an interface"
+msgstr "deftype/defrecordは1つ以上のプロトコルもしくはインターフェースを実装することができる"
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:107
+msgid "this is primarily to facilitate interop with the host (e.g. Java)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:108
+msgid "but opens the door to incidental multiple inheritance of implementation"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:109
+msgid "since a class can inherit from more than one interface, both of which implement the protocol"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/protocols.adoc:110
-msgid ""
-"You can implement a protocol on an interface ** this is primarily to facilitate interop with the host (e.g. Java)  ** "
-"but opens the door to incidental multiple inheritance of implementation *** since a class can inherit from more than "
-"one interface, both of which implement the protocol *** if one interface is derived from the other, the more derived "
-"is used, else which one is used is unspecified."
+msgid "if one interface is derived from the other, the more derived is used, else which one is used is unspecified."
 msgstr ""
 
 #. type: Plain text

--- a/i18n/po/content/reference/reader/ja.po
+++ b/i18n/po/content/reference/reader/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
-"PO-Revision-Date: 2019-02-18 20:22+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 02:31+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -15,31 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16 en/content/guides/learn/syntax.adoc:14
-#: en/content/guides/learn/flow.adoc:14 en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16 en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14 en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14 en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16 en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Plain text
 #: en/content/reference/transducers.adoc:39 en/content/reference/reader.adoc:179
@@ -168,22 +143,32 @@ msgstr ""
 "る。"
 
 #. type: Plain text
-#: en/content/reference/reader.adoc:38
+#: en/content/reference/reader.adoc:35
+msgid "Numbers - generally represented as per Java"
+msgstr "数値 - 一般的に Java と同様に表記される"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:36
 msgid ""
-"Numbers - generally represented as per Java ** Integers can be indefinitely long and will be read as Longs when in "
-"range and clojure.lang.BigInts otherwise. Integers with an N suffix are always read as BigInts. When possible, they "
-"can be specified in any base with radix from 2 to 36 (see http://docs.oracle.com/javase/7/docs/api/java/lang/Long."
-"html#parseLong(java.lang.String,%20int)[Long.parseLong()]); for example `2r101010`, `8r52`, `36r16`, and `42` are all "
-"the same Long.  ** Floating point numbers are read as Doubles; with M suffix they are read as BigDecimals.  ** Ratios "
-"are supported, e.g. `22/7`."
+"Integers can be indefinitely long and will be read as Longs when in range and clojure.lang.BigInts otherwise. "
+"Integers with an N suffix are always read as BigInts. When possible, they can be specified in any base with radix "
+"from 2 to 36 (see http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong(java.lang.String,%20int)"
+"[Long.parseLong()]); for example `2r101010`, `8r52`, `36r16`, and `42` are all the same Long."
 msgstr ""
-"数値 - 一般的に Java と同様に表記される。\n"
-"** 整数は長さの制限がなく、longの範囲内にある時はLongとして読み込まれ、それ以外の場合には clojrue.lang.BigIntとして読"
-"み込まれる。末尾にNが付いている整数は常にBigIntとして読み込まれる。可能な場合には2から36の基数を指定して表記することが"
-"できる。(参照: http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong(java.lang.String,%20int)[Long."
-"parseLong()])。 例えば `2r101010`、`8r52`、`36r16`,`42` は全て同じLongになる。\n"
-"** 浮動少数はDoubleとして読み込まれる。末尾にMが付いているとBigDecimalとして読み込まれる。\n"
-"** 分数もサポートされている。 (例： `22/7`)"
+"整数は長さの制限がなく、Longの範囲内にある時はLongとして読み込まれ、それ以外の場合には clojrue.lang.BigIntとして読み込"
+"まれる。末尾にNが付いている整数は常にBigIntとして読み込まれる。可能な場合には2から36の基数を指定して表記することができ"
+"る(参照: http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong(java.lang.String,%20int)[Long."
+"parseLong()])。例えば `2r101010`、`8r52`、`36r16`,`42` は全て同じLongになる。"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:37
+msgid "Floating point numbers are read as Doubles; with M suffix they are read as BigDecimals."
+msgstr "浮動小数点数はDoubleとして読み込まれる。末尾にMが付いているとBigDecimalとして読み込まれる。"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:38
+msgid "Ratios are supported, e.g. `22/7`."
+msgstr "分数もサポートされている(例: `22/7`)。"
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:39
@@ -207,24 +192,47 @@ msgid "Booleans - `true` and `false`"
 msgstr "ブーリアン - `true` と `false`"
 
 #. type: Plain text
+#: en/content/reference/reader.adoc:42
+msgid "Keywords - Keywords are like symbols, except:"
+msgstr "キーワード - キーワードはシンボルと似ているが、以下の点で異なる:"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:43
+msgid "They can and must begin with a colon, e.g. :fred."
+msgstr "コロン(:) で始まらなければならない(例：:fred)。"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:44
+msgid "They cannot contain '.' or name classes."
+msgstr "'.'を含めたりクラスの名前に使用したりできない。"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:45
+msgid "Like symbols, they can contain a namespace, `:person/name`"
+msgstr "シンボルと同様にネームスペースを含むことができる。 `:person/name`"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:46
+msgid "A keyword that begins with two colons is auto-resolved in the current namespace to a qualified keyword:"
+msgstr "コロン2つで始まるキーワードは現在のネームスペースにおいて修飾されたキーワードに自動的に解決される:"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:47
+msgid ""
+"If the keyword is unqualified, the namespace will be the current namespace. In `user`, `::rect` is read as `:user/"
+"rect`."
+msgstr ""
+"キーワードが修飾されていない場合、そのネームスペースは現在のネームスペースになる。 `user` では `::rect` は `user/"
+"rect` として読み込まれる。"
+
+#. type: Plain text
 #: en/content/reference/reader.adoc:48
 msgid ""
-"Keywords - Keywords are like symbols, except: ** They can and must begin with a colon, e.g. :fred.  ** They cannot "
-"contain '.' or name classes.  ** Like symbols, they can contain a namespace, `:person/name` ** A keyword that begins "
-"with two colons is auto-resolved in the current namespace to a qualified keyword: *** If the keyword is unqualified, "
-"the namespace will be the current namespace. In `user`, `::rect` is read as `:user/rect`.  *** If the keyword is "
-"qualified, the namespace will be resolved using aliases in the current namespace. In a namespace where `x` is aliased "
-"to `example`, `::x/foo` resolves to `:example/foo`."
+"If the keyword is qualified, the namespace will be resolved using aliases in the current namespace. In a namespace "
+"where `x` is aliased to `example`, `::x/foo` resolves to `:example/foo`."
 msgstr ""
-"キーワード - キーワードはシンボルと似ているが、以下の点で異なる: \n"
-"** コロン(:) で始まらなければならない(例：:fred)。\n"
-"** '.'を含めたりクラスの名前に使用したりできない。\n"
-"** シンボルと同様にネームスペースを含むことができる。 `:person/name` \n"
-"** コロン2つで始まるキーワードは現在のネームスペースにおいて修飾されたキーワードに自動的に解決される: \n"
-"*** キーワードが修飾されていない場合、そのネームスペースは現在のネームスペースになる。 `user` では `::rect` は `user/"
-"rect` として読み込まれる。\n"
-"*** キーワードが修飾されている場合、そのネームスペースは現在のネームスペースでのエイリアスを利用して解決される。 `x` "
-"が `example` にエイリアスされたネームスペースでは、 `::x/foo` は `:example/foo` に解決される。"
+"キーワードが修飾されている場合、そのネームスペースは現在のネームスペースでのエイリアスを利用して解決される。 `x` が "
+"`example` にエイリアスされたネームスペースでは、 `::x/foo` は `:example/foo` に解決される。"
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:49 en/content/community/editing.adoc:172
@@ -279,7 +287,7 @@ msgstr "ネームスペース付きマップ記法"
 #. type: Plain text
 #: en/content/reference/reader.adoc:67
 msgid "_Added in Clojure 1.9_"
-msgstr ""
+msgstr "_Clojure 1.9で追加された_"
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:69
@@ -298,27 +306,45 @@ msgid "A map literal with namespace syntax is read with the following difference
 msgstr "ネームスペース付きのマップリテラルの文法に対する読み込みは通常のマップに対する読み込みと以下の点が異なる:"
 
 #. type: Plain text
-#: en/content/reference/reader.adoc:76
+#: en/content/reference/reader.adoc:73
+msgid "Keys"
+msgstr "キー"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:74
+msgid "Keys that are keywords or symbols without a namespace are read with the default namespace."
+msgstr "ネームスペースなしのキーワードもしくはシンボルであるキーはデフォルトのネームスペースで読み込まれる。"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:75
 msgid ""
-"Keys ** Keys that are keywords or symbols without a namespace are read with the default namespace.  ** Keys that are "
-"keywords or symbols with a namespace are not affected *except* for the special namespace `_`, which is removed during "
-"read. This allows for the specification of keywords or symbols without namespaces as keys in a map literal with "
-"namespace syntax.  ** Keys that are not symbols or keywords are not affected."
+"Keys that are keywords or symbols with a namespace are not affected *except* for the special namespace `_`, which is "
+"removed during read. This allows for the specification of keywords or symbols without namespaces as keys in a map "
+"literal with namespace syntax."
 msgstr ""
-"キー\n"
-"** ネームスペースの指定がないキーもしくはシンボルはデフォルトのネームスペースで読み込まれる。\n"
-"** ネームスペースの指定があるシンボルもしくはキーワードは影響されずに読み込まれる。 *ただし* 、特別なネームスペース "
-"`_` は読み込み時に取り除かれるので扱いが異なる。これを使用することでネームスペースの指定があるマップの中で、ネームス"
-"ペースの指定がないキーワード、シンボルを使用することが可能になる。\n"
-"** キーワード、シンボルでないキーは影響を受けない。"
+"ネームスペースのあるシンボルもしくはキーワードであるキーは影響されずに読み込まれる。 *ただし* 、特別なネームスペース "
+"`_` は読み込み時に取り除かれるので扱いが異なる。これを使用することでネームスペースシンタックスのあるマップリテラルの中"
+"で、ネームスペースなしのキーワードやシンボルをキーとして指定することが可能になる。"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:76
+msgid "Keys that are not symbols or keywords are not affected."
+msgstr "キーワードもしくはシンボル以外のキーは影響を受けない。"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:77
+msgid "Values"
+msgstr "値"
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:78
+msgid "Values are not affected."
+msgstr "値は影響を受けない。"
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:79
-msgid "Values ** Values are not affected.  ** Nested map literal keys are not affected."
-msgstr ""
-"バリュー\n"
-"** バリューは影響されない。\n"
-"** ネストしたマップリテラルのキーは影響されない。"
+msgid "Nested map literal keys are not affected."
+msgstr "ネストしたマップリテラルのキーは影響を受けない。"
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:81 en/content/guides/weird_characters.adoc:474
@@ -769,7 +795,7 @@ msgstr ""
 #: en/content/reference/reader.adoc:212
 #, no-wrap
 msgid "Built-in tagged literals"
-msgstr ""
+msgstr "組み込みのタグ付きリテラル"
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:217
@@ -778,6 +804,9 @@ msgid ""
 "ss.fff+hh:mm\"`.  NOTE: Some of the elements of this format are optional. See the code for details.  The default "
 "reader will parse the supplied string into a `java.util.Date` by default. For example:"
 msgstr ""
+"Clojure 1.4では _instant_ と _UUID_ のタグ付きリテラルが導入された。instantは `#inst \"yyyy-mm-ddThh:mm:ss.fff+hh:mm"
+"\"` という形式をとる。 注意: この形式の一部の要素は省略可能だ。詳細はコードを参照。デフォルトのリーダーは与えられた文"
+"字列をパースしてデフォルトでは `java.util.Date` にする。例えば:"
 
 #. type: delimited block -
 #: en/content/reference/reader.adoc:222
@@ -787,6 +816,9 @@ msgid ""
 "(= java.util.Date (class instant))\n"
 ";=> true\n"
 msgstr ""
+"(def instant #inst \"2018-03-28T10:48:00.000\")\n"
+"(= java.util.Date (class instant))\n"
+";=> true\n"
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:225
@@ -795,6 +827,9 @@ msgid ""
 "one. For example, `clojure.instant/read-instant-calendar` will parse the literal into a `java.util.Calendar`, while "
 "`clojure.instant/read-instant-timestamp` will parse it into a `java.util.Timestamp`:"
 msgstr ""
+"pass[*data-readers*] は束縛可能な動的Varなので、デフォルトのリーダーを別のものに置き換えることができる。例えば "
+"`clojure.instant/read-instant-calendar` はリテラルをパースして `java.util.Calendar` にするが、 `clojure.instant/read-"
+"instant-timestamp` はリテラルをパースして `java.util.Timestamp` にする:"
 
 #. type: delimited block -
 #: en/content/reference/reader.adoc:229
@@ -804,6 +839,9 @@ msgid ""
 "  (= java.util.Calendar (class (read-string instant))))\n"
 ";=> true\n"
 msgstr ""
+"(binding [*data-readers* {'inst read-instant-calendar}]\n"
+"  (= java.util.Calendar (class (read-string instant))))\n"
+";=> true\n"
 
 #. type: delimited block -
 #: en/content/reference/reader.adoc:233
@@ -813,11 +851,14 @@ msgid ""
 "  (= java.util.Timestamp (class (read-string instant))))\n"
 ";=> true\n"
 msgstr ""
+"(binding [*data-readers* {'inst read-instant-timestamp}]\n"
+"  (= java.util.Timestamp (class (read-string instant))))\n"
+";=> true\n"
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:236
 msgid "The `#uuid` tagged literal will be parsed into a `java.util.UUID`:"
-msgstr ""
+msgstr "`#uuid` タグ付きリテラルはパースされて `java.util.UUID` になる:"
 
 #. type: delimited block -
 #: en/content/reference/reader.adoc:240
@@ -826,6 +867,8 @@ msgid ""
 "(= java.util.UUID (class (read-string \"#uuid \\\"3b8a31ed-fd89-4f1b-a00f-42e3d60cf5ce\\\"\")))\n"
 ";=> true\n"
 msgstr ""
+"(= java.util.UUID (class (read-string \"#uuid \\\"3b8a31ed-fd89-4f1b-a00f-42e3d60cf5ce\\\"\")))\n"
+";=> true\n"
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:242

--- a/i18n/po/content/reference/reducers/ja.po
+++ b/i18n/po/content/reference/reducers/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
-"PO-Revision-Date: 2018-05-04 06:05+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 02:16+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -17,39 +17,23 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4 en/content/reference/metadata.adoc:4
-#: en/content/reference/evaluation.adoc:4 en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4 en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4 en/content/reference/other_libraries.adoc:4
-#: en/content/reference/data_structures.adoc:4 en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4 en/content/reference/lisps.adoc:4
-#: en/content/reference/lazy.adoc:4 en/content/reference/repl_and_main.adoc:4 en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/multimethods.adoc:4
-#: en/content/search.adoc:4 en/content/about/clojureclr.adoc:4 en/content/about/functional_programming.adoc:4
-#: en/content/about/lisp.adoc:4 en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4 en/content/about/rationale.adoc:4
-#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4 en/content/privacy.adoc:4
-#: en/content/community/swag.adoc:4 en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
-#: en/content/community/downloads_older.adoc:4 en/content/community/libraries.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4 en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4 en/content/reference/transients.adoc:4
+#: en/content/reference/compilation.adoc:4 en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4 en/content/reference/transducers.adoc:4
+#: en/content/reference/refs.adoc:4 en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4 en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4 en/content/reference/data_structures.adoc:4 en/content/reference/atoms.adoc:4
+#: en/content/reference/repl_and_main.adoc:4 en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4 en/content/community/downloads_older.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4 en/content/404.adoc:4
+#: en/content/privacy.adoc:4 en/content/search.adoc:4 en/content/about/spec.adoc:4
+#: en/content/about/concurrent_programming.adoc:4 en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4 en/content/about/features.adoc:4
+#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/special_forms.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/metadata.adoc:15 en/content/reference/reader.adoc:13 en/content/reference/transients.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_functions.adoc:17 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/java_interop.adoc:15 en/content/reference/data_structures.adoc:16
-#: en/content/reference/datatypes.adoc:16 en/content/reference/agents.adoc:16 en/content/reference/protocols.adoc:15
-#: en/content/reference/reducers.adoc:15 en/content/reference/lazy.adoc:12 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/transducers.adoc:15 en/content/reference/vars.adoc:16 en/content/reference/namespaces.adoc:15
-#: en/content/reference/libs.adoc:16 en/content/reference/multimethods.adoc:15
-#: en/content/about/functional_programming.adoc:15 en/content/about/dynamic.adoc:16 en/content/about/spec.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/reference/reducers.adoc:1
@@ -153,13 +137,14 @@ msgid "Map colls are reduced with reduce-kv"
 msgstr "マップのコレクションは reduce-kv でreduceされる"
 
 #. type: Plain text
+#: en/content/reference/reducers.adoc:40
+msgid "When init is not provided, f is invoked with no arguments to produce an identity value"
+msgstr "init が与えられていない場合、 初期値を作り出すためにfが引数なしで呼び出される"
+
+#. type: Plain text
 #: en/content/reference/reducers.adoc:41
-msgid ""
-"When init is not provided, f is invoked with no arguments to produce an identity value ** _Note: f may be invoked "
-"multiple times to provide the identity value_"
-msgstr ""
-"init が与えられていない場合、 初期値を作り出すために f が引数なしで呼び出される。\n"
-"** _注: 初期値を作り出すために f が複数呼び出される場合がある。_"
+msgid "_Note: f may be invoked multiple times to provide the identity value_"
+msgstr "_注意: 初期値を作り出すためにfが複数呼び出される場合がある_"
 
 #. type: Plain text
 #: en/content/reference/reducers.adoc:43

--- a/i18n/po/content/reference/refs/ja.po
+++ b/i18n/po/content/reference/refs/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-05-04 06:03+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73 en/content/reference/namespaces.adoc:24

--- a/i18n/po/content/reference/repl_and_main/ja.po
+++ b/i18n/po/content/reference/repl_and_main/ja.po
@@ -6,8 +6,8 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
-"PO-Revision-Date: 2018-05-04 05:48+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
+"PO-Revision-Date: 2019-06-12 02:31+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
 "Language: ja\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73 en/content/reference/namespaces.adoc:24
@@ -102,42 +86,79 @@ msgid "With no options or args, runs an interactive Read-Eval-Print Loop"
 msgstr "オプションと引数の指定がない場合、インタラクティブな REPL (Read-Eval-Print Loop) を実行する"
 
 #. type: Plain text
+#: en/content/reference/repl_and_main.adoc:27
+msgid "init options:"
+msgstr "initオプション:"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:28
+msgid "-i, --init path Load a file or resource"
+msgstr "-i, --init パス ファイル、もしくはリソースをロードする"
+
+#. type: Plain text
 #: en/content/reference/repl_and_main.adoc:29
-msgid ""
-"init options: ** -i, --init path Load a file or resource ** -e, --eval string Evaluate expressions in string; print "
-"non-nil values"
-msgstr ""
-"initオプション:\n"
-"** -i, --init パス ファイル、もしくはリソースをロードする\n"
-"** -e, --eval 文字列 文字列中の式を評価する; 非nilな値をプリントする"
+msgid "-e, --eval string Evaluate expressions in string; print non-nil values"
+msgstr "-e, --eval 文字列 文字列中の式を評価する; 非nilな値をプリントする"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:30
+msgid "main options:"
+msgstr "mainオプション:"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:31
+msgid "-r, --repl Run a repl"
+msgstr "-r, --repl replを実行する"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:32
+msgid "path Run a script from a file or resource"
+msgstr "path ファイル、もしくはリソースからスクリプトを実行する"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:33
+msgid "- Run a script from standard input"
+msgstr "- 標準入力からスクリプトを実行する"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:34
+msgid "-m, --main A namespace to find a -main function for execution"
+msgstr "-m, --main 実行対象の-main関数を見つけるためのネームスペース"
 
 #. type: Plain text
 #: en/content/reference/repl_and_main.adoc:35
-msgid ""
-"main options: ** -r, --repl Run a repl ** path Run a script from a file or resource ** - Run a script from standard "
-"input ** -m, --main A namespace to find a -main function for execution ** -h, -?, --help Print this help message and "
-"exit"
-msgstr ""
-"mainオプション:\n"
-"** -r, --repl replを実行する\n"
-"** path ファイル、もしくはリソースからスクリプトを実行する\n"
-"** - 標準入力からスクリプトを実行する\n"
-"** -m, --main 実行対象の -main 関数を含むネームスペース\n"
-"** -h, -?, --help このメッセージをプリントし終了する"
+msgid "-h, -?, --help Print this help message and exit"
+msgstr "-h, -?, --help このメッセージをプリントして終了する"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:36
+msgid "operation:"
+msgstr "操作:"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:37
+msgid "Establishes thread-local bindings for commonly set!-able vars"
+msgstr "一般的に利用されるset!操作が可能なvarに対してスレッドローカルな束縛を行う"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:38
+msgid "Enters the user namespace"
+msgstr "userネームスペースに切り替える"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:39
+msgid "Binds \\*command-line-args* to a seq of strings containing command line args that appear after any main option"
+msgstr "\\*command-line-args* を、mainオプションの後に指定されたコマンドライン引数を含む文字列シーケンスに束縛する"
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:40
+msgid "Runs all init options in order"
+msgstr "全てのinitオプションを順に実行する"
 
 #. type: Plain text
 #: en/content/reference/repl_and_main.adoc:41
-msgid ""
-"operation: ** Establishes thread-local bindings for commonly set!-able vars ** Enters the user namespace ** Binds "
-"\\*command-line-args* to a seq of strings containing command line args that appear after any main option ** Runs all "
-"init options in order ** Runs a repl or script if requested"
-msgstr ""
-"操作:\n"
-"** 一般的に利用される set! 操作が可能な var に対してスレッドローカルな束縛を行う\n"
-"** userネームスペースに切り替える\n"
-"** *command-line-args* を、mainオプションの後に指定されたコマンドライン引数を含む文字列シーケンスに束縛する\n"
-"** 全てのinitオプションを順に実行する\n"
-"** repl、もしくは指定があればスクリプトを実行する"
+msgid "Runs a repl or script if requested"
+msgstr "repl、もしくは指定があればスクリプトを実行する"
 
 #. type: Plain text
 #: en/content/reference/repl_and_main.adoc:45

--- a/i18n/po/content/reference/sequences/ja.po
+++ b/i18n/po/content/reference/sequences/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,22 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ====
 #: en/content/reference/sequences.adoc:1 en/content/guides/spec.adoc:513 en/content/about/spec.adoc:234

--- a/i18n/po/content/reference/special_forms/ja.po
+++ b/i18n/po/content/reference/special_forms/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,23 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/reference/special_forms.adoc:1
@@ -811,17 +794,33 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/special_forms.adoc:336
+msgid "`:__ns__/keys` - _ns_ specifies the default namespace for the key to look up in the input"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/special_forms.adoc:337
+msgid "keys elements should not specify a namespace"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/special_forms.adoc:338
-msgid ""
-"`:__ns__/keys` - _ns_ specifies the default namespace for the key to look up in the input ** keys elements should not "
-"specify a namespace ** keys elements also define new local symbols, as with `:keys`"
+msgid "keys elements also define new local symbols, as with `:keys`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/special_forms.adoc:339
+msgid "`:__ns__/syms` - _ns_ specifies the default namespace for the symbol to look up in the input"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/special_forms.adoc:340
+msgid "syms elements should not specify a namespace"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/special_forms.adoc:341
-msgid ""
-"`:__ns__/syms` - _ns_ specifies the default namespace for the symbol to look up in the input ** syms elements should "
-"not specify a namespace ** syms elements also define new local symbols, as with `:syms`"
+msgid "syms elements also define new local symbols, as with `:syms`"
 msgstr ""
 
 #. type: delimited block -

--- a/i18n/po/content/reference/transducers/ja.po
+++ b/i18n/po/content/reference/transducers/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2018-04-15 14:23+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,23 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/transducers.adoc:1 en/content/news/2015/06/30/clojure-17.adoc:10

--- a/i18n/po/content/reference/transients/ja.po
+++ b/i18n/po/content/reference/transients/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -34,27 +34,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4 en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr "Rich Hickey 2015-01-01"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13 en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16 en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16 en/content/reference/macros.adoc:15
-#: en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11 en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16 en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title =
 #: en/content/reference/deps_and_cli.adoc:14 en/content/reference/transients.adoc:17
@@ -290,10 +269,23 @@ msgid "O(1) creation of persistent data structure when editing session finished"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/transients.adoc:86
+msgid "Same code structure as functional version"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/transients.adoc:87
+msgid "Capture return value, use for next call"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/transients.adoc:88
+msgid "Don't bash in place"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/transients.adoc:89
-msgid ""
-"Same code structure as functional version ** Capture return value, use for next call ** Don't bash in place ** Not "
-"persistent, so you can't hang onto interim values or alias"
+msgid "Not persistent, so you can't hang onto interim values or alias"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/po/content/reference/vars/ja.po
+++ b/i18n/po/content/reference/vars/ja.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: 2016-06-27 08:47+0900\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -15,22 +15,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15 en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16 en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16 en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/reader.adoc:13 en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15 en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17 en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16 en/content/guides/weird_characters.adoc:10
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10 en/content/guides/destructuring.adoc:11
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16 en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr "toc::[]"
 
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73 en/content/reference/namespaces.adoc:24
@@ -64,7 +48,7 @@ msgid "Vars and the Global Environment"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/vars.adoc:4 en/content/guides/getting_started.adoc:4
+#: en/content/reference/vars.adoc:4
 msgid "Rich Hickey 2016-01-14"
 msgstr ""
 

--- a/i18n/pot/content/about/dynamic/original.pot
+++ b/i18n/pot/content/about/dynamic/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,49 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ==

--- a/i18n/pot/content/about/functional_programming/original.pot
+++ b/i18n/pot/content/about/functional_programming/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,57 +17,33 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4
-#: en/content/reference/metadata.adoc:4 en/content/reference/evaluation.adoc:4
-#: en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4
+#: en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4
+#: en/content/reference/transients.adoc:4
 #: en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4
 #: en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4
+#: en/content/reference/transducers.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4
+#: en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4
 #: en/content/reference/data_structures.adoc:4
-#: en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4
-#: en/content/reference/lisps.adoc:4 en/content/reference/lazy.adoc:4
-#: en/content/reference/repl_and_main.adoc:4
-#: en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4
-#: en/content/reference/multimethods.adoc:4 en/content/search.adoc:4
-#: en/content/about/clojureclr.adoc:4
-#: en/content/about/functional_programming.adoc:4 en/content/about/lisp.adoc:4
-#: en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4
-#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4
-#: en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4
-#: en/content/privacy.adoc:4 en/content/community/swag.adoc:4
-#: en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
+#: en/content/reference/atoms.adoc:4 en/content/reference/repl_and_main.adoc:4
+#: en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4
 #: en/content/community/downloads_older.adoc:4
-#: en/content/community/libraries.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4
+#: en/content/404.adoc:4 en/content/privacy.adoc:4 en/content/search.adoc:4
+#: en/content/about/spec.adoc:4 en/content/about/concurrent_programming.adoc:4
+#: en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4
+#: en/content/about/features.adoc:4 en/content/about/rationale.adoc:4
+#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4
+#: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/sequences.adoc:15 en/content/reference/metadata.adoc:15
-#: en/content/reference/reader.adoc:13 en/content/reference/transients.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/datatypes.adoc:16 en/content/reference/agents.adoc:16
-#: en/content/reference/protocols.adoc:15 en/content/reference/reducers.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/transducers.adoc:15 en/content/reference/vars.adoc:16
-#: en/content/reference/namespaces.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/multimethods.adoc:15
-#: en/content/about/functional_programming.adoc:15
-#: en/content/about/dynamic.adoc:16 en/content/about/spec.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title =

--- a/i18n/pot/content/about/rationale/original.pot
+++ b/i18n/pot/content/about/rationale/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,39 +46,19 @@ msgstr ""
 msgid "Rich Hickey 2015-01-01"
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
-
 #. type: Title =
+#: en/content/reference/deps_and_cli.adoc:14
 #: en/content/reference/transients.adoc:17
 #: en/content/news/2013/06/28/clojure-clore-async-channels.adoc:10
 #: en/content/about/rationale.adoc:1
 #, no-wrap
 msgid "Rationale"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/guides.adoc:29 en/content/about/rationale.adoc:68
+#, no-wrap
+msgid "Libraries"
 msgstr ""
 
 #. type: Plain text
@@ -178,20 +158,58 @@ msgid "Core advantage still code-as-data and syntactic abstraction"
 msgstr ""
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:38
+msgid "What about the standard Lisps (Common Lisp and Scheme)?"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:39
+msgid "Slow/no innovation post standardization"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:40
+msgid "Core data structures mutable, not extensible"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:41
+msgid "No concurrency in specs"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:42
+msgid "Good implementations already exist for JVM (ABCL, Kawa, SISC et al)"
+msgstr ""
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:43
-msgid ""
-"What about the standard Lisps (Common Lisp and Scheme)? ** Slow/no "
-"innovation post standardization ** Core data structures mutable, not "
-"extensible ** No concurrency in specs ** Good implementations already exist "
-"for JVM (ABCL, Kawa, SISC et al)  ** Standard Lisps are their own platforms"
+msgid "Standard Lisps are their own platforms"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:44
+msgid "Clojure is a Lisp not constrained by backwards compatibility"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:45
+msgid "Extends the code-as-data paradigm to maps and vectors"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:46
+msgid "Defaults to immutability"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:47
+msgid "Core data structures are extensible abstractions"
 msgstr ""
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:48
-msgid ""
-"Clojure is a Lisp not constrained by backwards compatibility ** Extends the "
-"code-as-data paradigm to maps and vectors ** Defaults to immutability ** "
-"Core data structures are extensible abstractions ** Embraces a platform (JVM)"
+msgid "Embraces a platform (JVM)"
 msgstr ""
 
 #. type: Title ==
@@ -206,26 +224,50 @@ msgid "Immutable data + first-class functions"
 msgstr ""
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:53
+msgid "Could always be done in Lisp, by discipline/convention"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:54
+msgid ""
+"But if a data structure _can_ be mutated, dangerous to presume it won't be"
+msgstr ""
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:55
 msgid ""
-"Could always be done in Lisp, by discipline/convention ** But if a data "
-"structure _can_ be mutated, dangerous to presume it won't be ** In "
-"traditional Lisp, only the list data structure is structurally recursive"
+"In traditional Lisp, only the list data structure is structurally recursive"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:56
+msgid "Pure functional languages tend to strongly static types"
 msgstr ""
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:57
-msgid ""
-"Pure functional languages tend to strongly static types ** Not for everyone, "
-"or every task"
+msgid "Not for everyone, or every task"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:58
+msgid "Clojure is a functional language with a dynamic emphasis"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:59
+msgid "All data structures immutable & persistent, supporting recursion"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:60
+msgid "Heterogeneous collections, return types"
 msgstr ""
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:61
-msgid ""
-"Clojure is a functional language with a dynamic emphasis ** All data "
-"structures immutable & persistent, supporting recursion ** Heterogeneous "
-"collections, return types ** Dynamic polymorphism"
+msgid "Dynamic polymorphism"
 msgstr ""
 
 #. type: Title ==
@@ -235,49 +277,167 @@ msgid "Languages and Platforms"
 msgstr ""
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:65
+msgid "VMs, not OSes, are the platforms of the future, providing:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:66
+msgid "Type system"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:67
+msgid "Dynamic enforcement and safety"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:69
+msgid "Abstract away OSes"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:70
+msgid "_Huge_ set of facilities"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:71
+msgid "Built-in and 3rd-party"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:72
+msgid "Memory and other resource management"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:73
+msgid "GC is platform, not language, facility"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:74
+msgid "Bytecode + JIT compilation"
+msgstr ""
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:75
-msgid ""
-"VMs, not OSes, are the platforms of the future, providing: ** Type system "
-"*** Dynamic enforcement and safety ** Libraries *** Abstract away OSes *** "
-"_Huge_ set of facilities *** Built-in and 3rd-party ** Memory and other "
-"resource management *** GC is platform, not language, facility ** Bytecode + "
-"JIT compilation *** Abstracts away hardware"
+msgid "Abstracts away hardware"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:76
+msgid "Language as platform vs. language + platform"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:77
+msgid "Old way - each language defines its own runtime"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:78
+msgid "GC, bytecode, type system, libraries etc"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:79
+msgid "New way (JVM, .Net)"
 msgstr ""
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:80
-msgid ""
-"Language as platform vs. language + platform ** Old way - each language "
-"defines its own runtime *** GC, bytecode, type system, libraries etc ** New "
-"way (JVM, .Net)  *** Common runtime independent of language"
+msgid "Common runtime independent of language"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:81
+msgid "Language built for platform vs language ported-to platform"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:82
+msgid "Many new languages still take 'Language as platform' approach"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:83
+msgid "When ported, have platform-on-platform issues"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:84
+msgid "Memory management, type-system, threading issues"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:85
+msgid "Library duplication"
 msgstr ""
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:86
 msgid ""
-"Language built for platform vs language ported-to platform ** Many new "
-"languages still take 'Language as platform' approach ** When ported, have "
-"platform-on-platform issues *** Memory management, type-system, threading "
-"issues *** Library duplication *** If original language based on C, some "
-"extension libraries written in C don't come over"
+"If original language based on C, some extension libraries written in C don't "
+"come over"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:87
+msgid "Platforms are dictated by clients"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:88
+msgid "'Must run on JVM' or .Net vs 'must run on Unix' or Windows"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:89
+msgid "JVM has established track record and trust level"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:90
+msgid "Now also open source"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:91
+msgid "Interop with other code required"
 msgstr ""
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:92
+msgid "C linkage insufficient these days"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:93
+msgid "Java/JVM _is_language + platform"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:94
 msgid ""
-"Platforms are dictated by clients ** 'Must run on JVM' or .Net vs 'must run "
-"on Unix' or Windows ** JVM has established track record and trust level *** "
-"Now also open source ** Interop with other code required *** C linkage "
-"insufficient these days"
+"Not the original story, but other languages for JVM always existed, now "
+"embraced by Sun"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:95
+msgid "Java can be tedious, insufficiently expressive"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:96
+msgid "Lack of first-class functions, no type inference, etc"
 msgstr ""
 
 #. type: Plain text
 #: en/content/about/rationale.adoc:97
-msgid ""
-"Java/JVM _is_language + platform ** Not the original story, but other "
-"languages for JVM always existed, now embraced by Sun ** Java can be "
-"tedious, insufficiently expressive *** Lack of first-class functions, no "
-"type inference, etc ** Ability to call/consume Java is critical"
+msgid "Ability to call/consume Java is critical"
 msgstr ""
 
 #. type: Plain text
@@ -292,18 +452,30 @@ msgid "Object Orientation is overrated"
 msgstr ""
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:102
+msgid "Born of simulation, now used for everything, even when inappropriate"
+msgstr ""
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:103
 msgid ""
-"Born of simulation, now used for everything, even when inappropriate ** "
 "Encouraged by Java/C# in all situations, due to their lack of (idiomatic) "
 "support for anything else"
 msgstr ""
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:104
+msgid "Mutable stateful objects are the new spaghetti code"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:105
+msgid "Hard to understand, test, reason about"
+msgstr ""
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:106
-msgid ""
-"Mutable stateful objects are the new spaghetti code ** Hard to understand, "
-"test, reason about ** Concurrency disaster"
+msgid "Concurrency disaster"
 msgstr ""
 
 #. type: Plain text
@@ -354,11 +526,18 @@ msgid "Polymorphism yields extensible, flexible systems"
 msgstr ""
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:117
+msgid "Clojure multimethods decouple polymorphism from OO and types"
+msgstr ""
+
+#. type: Plain text
+#: en/content/about/rationale.adoc:118
+msgid "Supports multiple taxonomies"
+msgstr ""
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:119
-msgid ""
-"Clojure multimethods decouple polymorphism from OO and types ** Supports "
-"multiple taxonomies ** Dispatches via static, dynamic or external "
-"properties, metadata, etc"
+msgid "Dispatches via static, dynamic or external properties, metadata, etc"
 msgstr ""
 
 #. type: Title ==
@@ -368,10 +547,13 @@ msgid "Concurrency and the multi-core future"
 msgstr ""
 
 #. type: Plain text
+#: en/content/about/rationale.adoc:123
+msgid "Immutability makes much of the problem go away"
+msgstr ""
+
+#. type: Plain text
 #: en/content/about/rationale.adoc:124
-msgid ""
-"Immutability makes much of the problem go away ** Share freely between "
-"threads"
+msgid "Share freely between threads"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/about/spec/original.pot
+++ b/i18n/pot/content/about/spec/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,40 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ====

--- a/i18n/pot/content/about/state/original.pot
+++ b/i18n/pot/content/about/state/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,34 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ==

--- a/i18n/pot/content/community/books/original.pot
+++ b/i18n/pot/content/community/books/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -38,283 +38,169 @@ msgstr ""
 msgid "_Listed in order of descending release date of newest edition._"
 msgstr ""
 
-#. type: Plain text
-#: en/content/community/books.adoc:14 en/content/community/books.adoc:175
-#: en/content/community/companies.adoc:14
-#: en/content/community/companies.adoc:15
-msgid "|==="
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:19
+#. type: Table
+#: en/content/community/books.adoc:175
+#, no-wrap
 msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51Bvd25CstL._SL160."
-"jpg[Programming Clojure 3rd edition,link=\"http://a.co/bSxW6A6\"] | http://a."
-"co/bSxW6A6[Programming Clojure 3rd edition] + by Alex Miller, Stuart "
-"Halloway, Aaron Bedra + Feb 21, 2018"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:24
-msgid ""
-"| image::https://s3.amazonaws.com/titlepages.leanpub.com/elementsofclojure/"
-"small[Elements of Clojure,link=\"https://leanpub.com/elementsofclojure\"] | "
-"https://leanpub.com/elementsofclojure[Elements of Clojure] + by Zachary "
-"Tellman + Sep 27, 2017"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:29
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/41k50H6VpaL._SL160."
-"jpg[ClojureScript Unraveled,link=\"http://a.co/cDfN4n4\"] | http://a.co/"
-"cDfN4n4[Quick Clojure: Effective Functional Programming] + by Mark McDonnell "
-"+ Aug 23, 2017"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:34
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/518xLvhHZ1L._SL160.jpg[Web "
-"Development with Clojure,link=\"http://a.co/c2gI4l2\"] | http://a.co/"
-"c2gI4l2[Web Development with Clojure] + by Dmitri Sotnikov + Aug 23, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:39
-msgid ""
-"| image::https://s3.amazonaws.com/titlepages.leanpub.com/clojurescript-"
-"unraveled/small[ClojureScript Unraveled,link=\"https://leanpub.com/"
-"clojurescript-unraveled\"] | https://leanpub.com/clojurescript-"
-"unraveled[ClojureScript Unraveled] + by Andrey Antukh, Alejandro Gómez + Jul "
-"25, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:44
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51EwRiXh4ZL._SL160."
-"jpg[Learning ClojureScript, link=\"http://a.co/2X3MJn2\"] | http://a."
-"co/2X3MJn2[Learning ClojureScript] + by W. David Jarvis, Rafik Naccache, "
-"Allen Rohner + Jun 30, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:49
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51iq-PKIZ8L._SL160."
-"jpg[Professional Clojure, link=\"http://a.co/bSHZ7X3\"] | http://a.co/"
-"bSHZ7X3[Professional Clojure] + by Jeremy Anderson, Michael Gaare, Justin "
-"Holguín, Nick Bailey, and Timothy Pratley + Jun 7, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:54
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/61TJZjnjO0L._SL160."
-"jpg[Mastering Clojure, link=\"http://a.co/bTLhJ2d\"] | http://a.co/"
-"bTLhJ2d[Mastering Clojure] + by Akhil Wali + Mar 28, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:59
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/61p47dd81cL._SL160."
-"jpg[Clojure for Java Developers, link=\"http://a.co/029aVrm\"] | http://a."
-"co/029aVrm[Clojure for Java Developers] + by Eduardo Diaz + Feb 23, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:64
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51ofF2ckdkL._SL160."
-"jpg[Clojure for Finance, link=\"http://a.co/fbHnhEM\"] | http://a.co/"
-"fbHnhEM[Clojure for Finance] + by Timothy Washington + Jan 11, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:69
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51QWOEjmtIL._SL160."
-"jpg[Clojure In Action, link=\"http://a.co/a4hDbTn\"] | http://a.co/"
-"a4hDbTn[Clojure In Action] + by Amit Rathore + Jan 1, 2016"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:74
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/6112vbQYDLL._SL160."
-"jpg[Clojure for the Brave and True,link=\"http://a.co/bsviqV7\"] | http://a."
-"co/bsviqV7[Clojure for the Brave and True] + by Daniel Higginbotham + Oct "
-"23, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:79
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51aMgNS%2BK7L._SL160."
-"jpg[Clojure Recipes,link=\"http://a.co/clSHVQi\"] | http://a.co/"
-"clSHVQi[Clojure Recipes] + by Julian Gamble + Oct 23, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:84
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/41iH5aTHB3L._SL160."
-"jpg[Clojure Applied,link=\"http://a.co/1HL2XPF\"] | http://a."
-"co/1HL2XPF[Clojure Applied: From Practice to Practitioner] + by Ben "
-"Vandgrift, Alex Miller + Sept 6, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:89
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51ki-47i6bL._SL160."
-"jpg[Clojure for Data Science,link=\"http://a.co/idtKjhS\"] | http://a.co/"
-"idtKjhS[Clojure for Data Science] + by Henry Garner + Sept 3, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:94
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51Nym1wJXVL._SL160."
-"jpg[Clojure High Performance Programming,link=\"http://a.co/7adcmsl\"] | "
-"http://a.co/7adcmsl[Clojure High Performance Programming] + by Shantanu "
-"Kumar + Sept 1, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:99
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/515vh5czqnL._SL160."
-"jpg[Clojure Data Structures and Algorithms,link=\"http://a.co/g7JAFAS\"] | "
-"http://a.co/g7JAFAS[Clojure Data Structures and Algorithms] + by Rafik "
-"Naccache + Aug 19, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:104
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/5122uV93jfL._SL160.jpg[Living "
-"Clojure,link=\"http://a.co/1m2Zt4p\"] | http://a.co/1m2Zt4p[Living Clojure] "
-"+ by Carin Meier + Apr 30, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:109
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51l1oGz9N7L._SL160."
-"jpg[Clojure Reactive Programming,link=\"http://a.co/fhyaFka\"] | http://a.co/"
-"fhyaFka[Clojure Reactive Programming] + by Leonardo Borges + Mar 24, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:114
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51XnilmUaIL._SL160."
-"jpg[Clojure Web Development Essentials,link=\"http://a.co/2FlRxd5\"] | "
-"http://a.co/2FlRxd5[Clojure Web Development Essentials] + by Ryan Baldwin + "
-"Feb 16, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:119
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51-B3kElSiL._SL160."
-"jpg[Clojure Data Analysis Cookbook, link=\"http://a.co/gIwPEkt\"] | http://a."
-"co/gIwPEkt[Clojure Data Analysis Cookbook] + by Eric Rochester + Jan 22, 2015"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:124
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51nhUEYSLhL._SL160."
-"jpg[Mastering Clojure Macros,link=\"http://a.co/4VjjiQJ\"] | http://a."
-"co/4VjjiQJ[Mastering Clojure Macros] + by Colin Jones + Sept 5, 2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:129
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/518RxlXpXsL._SL160.jpg[The "
-"Joy of Clojure,link=\"http://a.co/evdNcOs\"] | http://a.co/evdNcOs[The Joy "
-"of Clojure] + by Michael Fogus, Chris Houser + Jun 13, 2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:134
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51gyxyvmX3L._SL160."
-"jpg[Mastering Clojure Data Analysis,link=\"http://a.co/bYwhMwH\"] | http://a."
-"co/bYwhMwH[Mastering Clojure Data Analysis] + by Eric Rochester + May 26, "
-"2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:139
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51Af%2B5qKOeL._SL160."
-"jpg[Clojure for Machine Learning,link=\"http://a.co/7PRmDOK\"] | http://a."
-"co/7PRmDOK[Clojure for Machine Learning] + by Akhil Wali + Apr 24, 2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:144
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51NPZu-5PiL._SL160."
-"jpg[Clojure Cookbook, link=\"http://a.co/1K6SZSI\"] | http://a."
-"co/1K6SZSI[Clojure Cookbook] + by Luke VanderHart and Ryan Neufeld + Mar 24, "
-"2014"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:149
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/515hwMhZELL._SL160."
-"jpg[Clojure for Domain-specific Languages,link=\"http://a.co/3rwXJkx\"] | "
-"http://a.co/3rwXJkx[Clojure for Domain-specific Languages] + by Ryan Kelker "
-"+ Dec 18, 2013"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:154
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51i1Cn-IqdL._SL160."
-"jpg[Functional Programming Patterns in Scala and Clojure,link=\"http://a."
-"co/2J3jvLX\"] | http://a.co/2J3jvLX[Functional Programming Patterns in Scala "
-"and Clojure] + by Michael Bevilacqua-Linn + Nov 2, 2013"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:159
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51KgF%2B-38WL._SL160."
-"jpg[ClojureScript: Up and Running,link=\"http://a.co/74IUDUu\"] | http://a."
-"co/74IUDUu[ClojureScript: Up and Running] + by Stuart Sierra, Luke "
-"VanderHart + Nov 10, 2012"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:164
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/41sY2b6MKiL._SL160."
-"jpg[Clojure Programming,link=\"http://a.co/jiaX8tX\"] | http://a.co/"
-"jiaX8tX[Clojure Programming] + by Chas Emerick, Brian Carper, Christophe "
-"Grand + Apr 22, 2012"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:169
-msgid ""
-"| image::http://clojure-buch.de/cover.jpg[Clojure,link=\"http://clojure-buch."
-"de/\",width=130] | http://clojure-buch.de/[Clojure] + by Stefan Kamphausen, "
-"Tim Oliver Kaiser + Sep 20, 2010"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/books.adoc:174
-msgid ""
-"| image::http://ecx.images-amazon.com/images/I/51dWGdAPwUL._SL160."
-"jpg[Practical Clojure, link=\"http://a.co/fWbYqs5\"] | http://a.co/"
-"fWbYqs5[Practical Clojure] + by Luke VanderHart, Stuart Sierra + Jun 1, 2010"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51Bvd25CstL._SL160.jpg[Programming Clojure 3rd edition,link=\"http://a.co/bSxW6A6\"]\n"
+"| http://a.co/bSxW6A6[Programming Clojure 3rd edition] +\n"
+"by Alex Miller, Stuart Halloway, Aaron Bedra +\n"
+"Feb 21, 2018\n"
+"\n"
+"| image::https://s3.amazonaws.com/titlepages.leanpub.com/elementsofclojure/small[Elements of Clojure,link=\"https://leanpub.com/elementsofclojure\"]\n"
+"| https://leanpub.com/elementsofclojure[Elements of Clojure] +\n"
+"by Zachary Tellman +\n"
+"Sep 27, 2017\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/41k50H6VpaL._SL160.jpg[ClojureScript Unraveled,link=\"http://a.co/cDfN4n4\"]\n"
+"| http://a.co/cDfN4n4[Quick Clojure: Effective Functional Programming] +\n"
+"by Mark McDonnell +\n"
+"Aug 23, 2017\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/518xLvhHZ1L._SL160.jpg[Web Development with Clojure,link=\"http://a.co/c2gI4l2\"]\n"
+"| http://a.co/c2gI4l2[Web Development with Clojure] +\n"
+"by Dmitri Sotnikov +\n"
+"Aug 23, 2016\n"
+"\n"
+"| image::https://s3.amazonaws.com/titlepages.leanpub.com/clojurescript-unraveled/small[ClojureScript Unraveled,link=\"https://leanpub.com/clojurescript-unraveled\"]\n"
+"| https://leanpub.com/clojurescript-unraveled[ClojureScript Unraveled] +\n"
+"by Andrey Antukh, Alejandro Gómez +\n"
+"Jul 25, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51EwRiXh4ZL._SL160.jpg[Learning ClojureScript, link=\"http://a.co/2X3MJn2\"]\n"
+"| http://a.co/2X3MJn2[Learning ClojureScript] +\n"
+"by W. David Jarvis, Rafik Naccache, Allen Rohner +\n"
+"Jun 30, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51iq-PKIZ8L._SL160.jpg[Professional Clojure, link=\"http://a.co/bSHZ7X3\"]\n"
+"| http://a.co/bSHZ7X3[Professional Clojure] +\n"
+"by Jeremy Anderson, Michael Gaare, Justin Holguín, Nick Bailey, and Timothy Pratley +\n"
+"Jun 7, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/61TJZjnjO0L._SL160.jpg[Mastering Clojure, link=\"http://a.co/bTLhJ2d\"]\n"
+"| http://a.co/bTLhJ2d[Mastering Clojure] +\n"
+"by Akhil Wali +\n"
+"Mar 28, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/61p47dd81cL._SL160.jpg[Clojure for Java Developers, link=\"http://a.co/029aVrm\"]\n"
+"| http://a.co/029aVrm[Clojure for Java Developers] +\n"
+"by Eduardo Diaz +\n"
+"Feb 23, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51ofF2ckdkL._SL160.jpg[Clojure for Finance, link=\"http://a.co/fbHnhEM\"]\n"
+"| http://a.co/fbHnhEM[Clojure for Finance] +\n"
+"by Timothy Washington +\n"
+"Jan 11, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51QWOEjmtIL._SL160.jpg[Clojure In Action, link=\"http://a.co/a4hDbTn\"]\n"
+"| http://a.co/a4hDbTn[Clojure In Action] +\n"
+"by Amit Rathore +\n"
+"Jan 1, 2016\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/6112vbQYDLL._SL160.jpg[Clojure for the Brave and True,link=\"http://a.co/bsviqV7\"]\n"
+"| http://a.co/bsviqV7[Clojure for the Brave and True] +\n"
+"by Daniel Higginbotham +\n"
+"Oct 23, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51aMgNS%2BK7L._SL160.jpg[Clojure Recipes,link=\"http://a.co/clSHVQi\"]\n"
+"| http://a.co/clSHVQi[Clojure Recipes] +\n"
+"by Julian Gamble +\n"
+"Oct 23, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/41iH5aTHB3L._SL160.jpg[Clojure Applied,link=\"http://a.co/1HL2XPF\"]\n"
+"| http://a.co/1HL2XPF[Clojure Applied: From Practice to Practitioner] +\n"
+"by Ben Vandgrift, Alex Miller +\n"
+"Sept 6, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51ki-47i6bL._SL160.jpg[Clojure for Data Science,link=\"http://a.co/idtKjhS\"]\n"
+"| http://a.co/idtKjhS[Clojure for Data Science] +\n"
+"by Henry Garner +\n"
+"Sept 3, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51Nym1wJXVL._SL160.jpg[Clojure High Performance Programming,link=\"http://a.co/7adcmsl\"]\n"
+"| http://a.co/7adcmsl[Clojure High Performance Programming] +\n"
+"by Shantanu Kumar +\n"
+"Sept 1, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/515vh5czqnL._SL160.jpg[Clojure Data Structures and Algorithms,link=\"http://a.co/g7JAFAS\"]\n"
+"| http://a.co/g7JAFAS[Clojure Data Structures and Algorithms] +\n"
+"by Rafik Naccache +\n"
+"Aug 19, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/5122uV93jfL._SL160.jpg[Living Clojure,link=\"http://a.co/1m2Zt4p\"]\n"
+"| http://a.co/1m2Zt4p[Living Clojure] +\n"
+"by Carin Meier +\n"
+"Apr 30, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51l1oGz9N7L._SL160.jpg[Clojure Reactive Programming,link=\"http://a.co/fhyaFka\"]\n"
+"| http://a.co/fhyaFka[Clojure Reactive Programming] +\n"
+"by Leonardo Borges +\n"
+"Mar 24, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51XnilmUaIL._SL160.jpg[Clojure Web Development Essentials,link=\"http://a.co/2FlRxd5\"]\n"
+"| http://a.co/2FlRxd5[Clojure Web Development Essentials] +\n"
+"by Ryan Baldwin +\n"
+"Feb 16, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51-B3kElSiL._SL160.jpg[Clojure Data Analysis Cookbook, link=\"http://a.co/gIwPEkt\"]\n"
+"| http://a.co/gIwPEkt[Clojure Data Analysis Cookbook] +\n"
+"by Eric Rochester +\n"
+"Jan 22, 2015\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51nhUEYSLhL._SL160.jpg[Mastering Clojure Macros,link=\"http://a.co/4VjjiQJ\"]\n"
+"| http://a.co/4VjjiQJ[Mastering Clojure Macros] +\n"
+"by Colin Jones +\n"
+"Sept 5, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/518RxlXpXsL._SL160.jpg[The Joy of Clojure,link=\"http://a.co/evdNcOs\"]\n"
+"| http://a.co/evdNcOs[The Joy of Clojure] +\n"
+"by Michael Fogus, Chris Houser +\n"
+"Jun 13, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51gyxyvmX3L._SL160.jpg[Mastering Clojure Data Analysis,link=\"http://a.co/bYwhMwH\"]\n"
+"| http://a.co/bYwhMwH[Mastering Clojure Data Analysis] +\n"
+"by Eric Rochester +\n"
+"May 26, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51Af%2B5qKOeL._SL160.jpg[Clojure for Machine Learning,link=\"http://a.co/7PRmDOK\"]\n"
+"| http://a.co/7PRmDOK[Clojure for Machine Learning] +\n"
+"by Akhil Wali +\n"
+"Apr 24, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51NPZu-5PiL._SL160.jpg[Clojure Cookbook, link=\"http://a.co/1K6SZSI\"]\n"
+"| http://a.co/1K6SZSI[Clojure Cookbook] +\n"
+"by Luke VanderHart and Ryan Neufeld +\n"
+"Mar 24, 2014\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/515hwMhZELL._SL160.jpg[Clojure for Domain-specific Languages,link=\"http://a.co/3rwXJkx\"]\n"
+"| http://a.co/3rwXJkx[Clojure for Domain-specific Languages] +\n"
+"by Ryan Kelker +\n"
+"Dec 18, 2013\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51i1Cn-IqdL._SL160.jpg[Functional Programming Patterns in Scala and Clojure,link=\"http://a.co/2J3jvLX\"]\n"
+"| http://a.co/2J3jvLX[Functional Programming Patterns in Scala and Clojure] +\n"
+"by Michael Bevilacqua-Linn +\n"
+"Nov 2, 2013\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51KgF%2B-38WL._SL160.jpg[ClojureScript: Up and Running,link=\"http://a.co/74IUDUu\"]\n"
+"| http://a.co/74IUDUu[ClojureScript: Up and Running] +\n"
+"by Stuart Sierra, Luke VanderHart +\n"
+"Nov 10, 2012\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/41sY2b6MKiL._SL160.jpg[Clojure Programming,link=\"http://a.co/jiaX8tX\"]\n"
+"| http://a.co/jiaX8tX[Clojure Programming] +\n"
+"by Chas Emerick, Brian Carper, Christophe Grand +\n"
+"Apr 22, 2012\n"
+"\n"
+"| image::http://clojure-buch.de/cover.jpg[Clojure,link=\"http://clojure-buch.de/\",width=130]\n"
+"| http://clojure-buch.de/[Clojure] +\n"
+"by Stefan Kamphausen, Tim Oliver Kaiser +\n"
+"Sep 20, 2010\n"
+"\n"
+"| image::http://ecx.images-amazon.com/images/I/51dWGdAPwUL._SL160.jpg[Practical Clojure, link=\"http://a.co/fWbYqs5\"]\n"
+"| http://a.co/fWbYqs5[Practical Clojure] +\n"
+"by Luke VanderHart, Stuart Sierra +\n"
+"Jun 1, 2010\n"
+"\n"
 msgstr ""

--- a/i18n/pot/content/community/companies/original.pot
+++ b/i18n/pot/content/community/companies/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,13 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/community/books.adoc:14 en/content/community/books.adoc:175
-#: en/content/community/companies.adoc:14
-#: en/content/community/companies.adoc:15
-msgid "|==="
-msgstr ""
 
 #. type: Title =
 #: en/content/community/companies.adoc:1
@@ -48,4 +41,10 @@ msgstr ""
 msgid ""
 "Also, check out the <<success_stories#,Clojure Success Stories>> and "
 "<<community_stories#,Community Stories>> pages!"
+msgstr ""
+
+#. type: Table
+#: en/content/community/companies.adoc:15
+#, no-wrap
+msgid "include::companies.csv[]\n"
 msgstr ""

--- a/i18n/pot/content/community/editing/original.pot
+++ b/i18n/pot/content/community/editing/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -48,6 +48,7 @@ msgstr ""
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:49 en/content/community/editing.adoc:172
+#: en/content/guides/learn/sequential_colls.adoc:102
 #, no-wrap
 msgid "Lists"
 msgstr ""
@@ -130,13 +131,18 @@ msgstr ""
 msgid "Text markup"
 msgstr ""
 
-#. type: Plain text
-#: en/content/community/editing.adoc:59
+#. type: Table
+#: en/content/community/editing.adoc:58
+#, no-wrap
 msgid ""
-"|=== | markup | effect | pass:[_italic_] | _italic_ | pass:[*bold*] | *bold* "
-"| pass:[_**italic and bold**_] | _**italic and bold**_ | pass:[`inline "
-"code`] | `inline code` | pass:[(C) (R) (TM)] | (C) (R) (TM)  | pass:[-- ...] "
-"| -- ...  | pass:[-> <- => <=] | -> <- => <= |==="
+"| markup | effect\n"
+"| pass:[_italic_] | _italic_\n"
+"| pass:[*bold*] | *bold*\n"
+"| pass:[_**italic and bold**_] | _**italic and bold**_\n"
+"| pass:[`inline code`] | `inline code`\n"
+"| pass:[(C) (R) (TM)] | (C) (R) (TM)\n"
+"| pass:[-- ...] | -- ...\n"
+"| pass:[-> <- => <=] | -> <- => <=\n"
 msgstr ""
 
 #. type: Plain text
@@ -375,8 +381,18 @@ msgid "first"
 msgstr ""
 
 #. type: Plain text
+#: en/content/community/editing.adoc:187
+msgid "second"
+msgstr ""
+
+#. type: Plain text
+#: en/content/community/editing.adoc:188
+msgid "nested"
+msgstr ""
+
+#. type: Plain text
 #: en/content/community/editing.adoc:189
-msgid "second ** nested *** more nested"
+msgid "more nested"
 msgstr ""
 
 #. type: Plain text
@@ -466,21 +482,14 @@ msgid ""
 "This is a basic table example however:"
 msgstr ""
 
-#. type: delimited block -
-#: en/content/community/editing.adoc:235
+#. type: Table
+#: en/content/community/editing.adoc:234 en/content/community/editing.adoc:242
 #, no-wrap
 msgid ""
 "[options=\"header\"]\n"
-"|===\n"
 "| col1 | col2\n"
 "| a | b\n"
 "| b | c\n"
-"|===\n"
-msgstr ""
-
-#. type: Plain text
-#: en/content/community/editing.adoc:243
-msgid "|=== | col1 | col2 | a | b | b | c |==="
 msgstr ""
 
 #. type: Title ==

--- a/i18n/pot/content/community/etiquette/original.pot
+++ b/i18n/pot/content/community/etiquette/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -102,12 +102,28 @@ msgid "Leave people out of it"
 msgstr ""
 
 #. type: Plain text
+#: en/content/community/etiquette.adoc:29
+msgid "Avoid rhetorical devices:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/community/etiquette.adoc:30
+msgid "Superfluous or opinion-laden adjectives"
+msgstr ""
+
+#. type: Plain text
+#: en/content/community/etiquette.adoc:31
+msgid "Claims to speak for the community, or that everyone agrees with you."
+msgstr ""
+
+#. type: Plain text
+#: en/content/community/etiquette.adoc:32
+msgid "Threats of what will happen unless things go your way"
+msgstr ""
+
+#. type: Plain text
 #: en/content/community/etiquette.adoc:33
-msgid ""
-"Avoid rhetorical devices: ** Superfluous or opinion-laden adjectives ** "
-"Claims to speak for the community, or that everyone agrees with you.  ** "
-"Threats of what will happen unless things go your way ** Any flavor of 'the "
-"sky is falling'"
+msgid "Any flavor of 'the sky is falling'"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/community/training/original.pot
+++ b/i18n/pot/content/community/training/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -47,20 +47,21 @@ msgid ""
 "courses."
 msgstr ""
 
-#. type: Plain text
-#: en/content/community/training.adoc:28
+#. type: Table
+#: en/content/community/training.adoc:27
+#, no-wrap
 msgid ""
-"|=== | Company | Location | Courses | Link | contact | Cognitect | North "
-"America | All levels | https://cognitect.com/services.html | sales@cognitect."
-"com + +1 919.283.2748 | BraveAndTrue | North America | All levels | https://"
-"www.braveclojure.com/training | daniel@braveclojure.com | Nilenso | India | "
-"Enterprise Clojure | https://nilenso.com | hello@nilenso.com + tel:"
-"+918040937123 | Starweaver | Global | Clojure in a Nutshell | https://www."
-"starweaver.com | USA: +1-646-883-1460 + UK: +44 20 3289 3277 + "
-"helpdesk@starweaver.com | Peter Taoussanis | Europe | Enterprise Clojure | "
-"https://www.taoensso.com | ptaoussanis@taoensso.com | Adam Bard | North "
-"America | Clojure Training | http://clojuretraining.ca | "
-"learnclojure@adambard.com |==="
+"| Company | Location | Courses | Link | contact\n"
+"| Cognitect | North America | All levels | https://cognitect.com/services.html | sales@cognitect.com +\n"
+"+1 919.283.2748\n"
+"| BraveAndTrue | North America | All levels | https://www.braveclojure.com/training | daniel@braveclojure.com\n"
+"| Nilenso | India | Enterprise Clojure | https://nilenso.com | hello@nilenso.com +\n"
+"tel:+918040937123\n"
+"| Starweaver | Global | Clojure in a Nutshell | https://www.starweaver.com | USA: +1-646-883-1460 +\n"
+"UK: +44 20 3289 3277 +\n"
+"helpdesk@starweaver.com\n"
+"| Peter Taoussanis | Europe | Enterprise Clojure | https://www.taoensso.com | ptaoussanis@taoensso.com\n"
+"| Adam Bard | North America | Clojure Training | http://clojuretraining.ca | learnclojure@adambard.com\n"
 msgstr ""
 
 #. type: Title ==
@@ -82,14 +83,14 @@ msgstr ""
 msgid "Online courses"
 msgstr ""
 
-#. type: Plain text
-#: en/content/community/training.adoc:44
+#. type: Table
+#: en/content/community/training.adoc:43
+#, no-wrap
 msgid ""
-"|=== | Link | Short description | https://lambdaisland.com | A series of "
-"video tutorial about web development using ClojureScript and Clojure | "
-"https://purelyfunctional.tv | Our mission is to help people thrive with "
-"Functional Programming | https://www.udemy.com/learning-clojure | Will teach "
-"you how to write Clojure code and structure Clojure products |==="
+"| Link | Short description\n"
+"| https://lambdaisland.com | A series of video tutorial about web development using ClojureScript and Clojure\n"
+"| https://purelyfunctional.tv | Our mission is to help people thrive with Functional Programming\n"
+"| https://www.udemy.com/learning-clojure | Will teach you how to write Clojure code and structure Clojure products\n"
 msgstr ""
 
 #. type: Title ===

--- a/i18n/pot/content/guides/comparators/original.pot
+++ b/i18n/pot/content/guides/comparators/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -97,37 +97,53 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/guides/comparators.adoc:41
+msgid "Write either a 3-way comparator or a boolean comparator:"
+msgstr ""
+
+#. type: Plain text
 #: en/content/guides/comparators.adoc:42
 msgid ""
-"Write either a 3-way comparator or a boolean comparator: ** A 3-way "
-"comparator takes 2 values, _x_ and _y_, and returns a Java 32-bit _int_ that "
-"is negative if"
+"A 3-way comparator takes 2 values, _x_ and _y_, and returns a Java 32-bit "
+"_int_ that is negative if"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/comparators.adoc:44
+msgid ""
+"_x_ comes before _y_, positive if _x_ comes after _y_, or 0 if they are "
+"equal. Use values -1, 0, and 1 if you have no reason to prefer other return "
+"values."
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/comparators.adoc:45
+msgid ""
+"A boolean comparator takes 2 values, _x_ and _y_, and returns true if _x_ "
+"comes before _y_, or"
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/comparators.adoc:48
-#, no-wrap
 msgid ""
-"_x_ comes before _y_, positive if _x_ comes after _y_, or 0 if they are equal. Use values -1, 0, and 1\n"
-"if you have no reason to prefer other return values.\n"
-"** A boolean comparator takes 2 values, _x_ and _y_, and returns true if _x_ comes before _y_, or\n"
-"    false otherwise (including if _x_ and _y_ are equal). `<` and `>` are good examples. `\\<=`\n"
-"    and `>=` are not. Performance note: your boolean comparator may be called twice to distinguish\n"
-"    between the \"comes after\" or \"equals\" cases.\n"
+"false otherwise (including if _x_ and _y_ are equal). `<` and `>` are good "
+"examples. `\\<=` and `>=` are not. Performance note: your boolean comparator "
+"may be called twice to distinguish between the \"comes after\" or \"equals\" "
+"cases."
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/comparators.adoc:49
-#, no-wrap
-msgid "Reverse the sort by reversing the order that you give the arguments to an existing comparator.\n"
+msgid ""
+"Reverse the sort by reversing the order that you give the arguments to an "
+"existing comparator."
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/comparators.adoc:51
-#, no-wrap
 msgid ""
-"Compare equal-length Clojure vectors containing \"sort keys\" in order to do a multi-field comparison\n"
-"between values.\n"
+"Compare equal-length Clojure vectors containing \"sort keys\" in order to do "
+"a multi-field comparison between values."
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/guides/deps_and_cli/original.pot
+++ b/i18n/pot/content/guides/deps_and_cli/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title =
 #: en/content/guides/deps_and_cli.adoc:1

--- a/i18n/pot/content/guides/destructuring/original.pot
+++ b/i18n/pot/content/guides/destructuring/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/reference/macros.adoc:1 en/content/guides/spec.adoc:782

--- a/i18n/pot/content/guides/faq/original.pot
+++ b/i18n/pot/content/guides/faq/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/reference/deps_and_cli.adoc:1 en/content/guides/faq.adoc:203

--- a/i18n/pot/content/guides/getting_started/original.pot
+++ b/i18n/pot/content/guides/getting_started/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title =
 #: en/content/guides/getting_started.adoc:1

--- a/i18n/pot/content/guides/guides/original.pot
+++ b/i18n/pot/content/guides/guides/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -100,8 +100,8 @@ msgstr ""
 msgid "<<deps_and_cli#,Deps and CLI>>"
 msgstr ""
 
-#. type: Title ===
-#: en/content/guides/guides.adoc:29
+#. type: Plain text
+#: en/content/guides/guides.adoc:29 en/content/about/rationale.adoc:68
 #, no-wrap
 msgid "Libraries"
 msgstr ""

--- a/i18n/pot/content/guides/higher_order_functions/original.pot
+++ b/i18n/pot/content/guides/higher_order_functions/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/guides/higher_order_functions.adoc:1

--- a/i18n/pot/content/guides/learn/flow/original.pot
+++ b/i18n/pot/content/guides/learn/flow/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,40 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ===
 #: en/content/guides/reader_conditionals.adoc:120
@@ -532,23 +498,33 @@ msgid "Clojure provides recur and the sequence abstraction"
 msgstr ""
 
 #. type: Plain text
+#: en/content/guides/learn/flow.adoc:241
+msgid "`recur` is \"classic\" recursion"
+msgstr ""
+
+#. type: Plain text
 #: en/content/guides/learn/flow.adoc:242
-msgid ""
-"`recur` is \"classic\" recursion ** Consumers don't control it, considered a "
-"lower-level facility"
+msgid "Consumers don't control it, considered a lower-level facility"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:243
+msgid "Sequences represent iteration as values"
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:244
-msgid ""
-"Sequences represent iteration as values ** Consumers can partially iterate"
+msgid "Consumers can partially iterate"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:245
+msgid "Reducers represent iteration as function composition"
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:246
-msgid ""
-"Reducers represent iteration as function composition ** Added in Clojure "
-"1.5, not covered here"
+msgid "Added in Clojure 1.5, not covered here"
 msgstr ""
 
 #. type: Title ===
@@ -558,10 +534,18 @@ msgid "`loop` and `recur`"
 msgstr ""
 
 #. type: Plain text
+#: en/content/guides/learn/flow.adoc:250
+msgid "Functional looping construct"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:251
+msgid "`loop` defines bindings"
+msgstr ""
+
+#. type: Plain text
 #: en/content/guides/learn/flow.adoc:252
-msgid ""
-"Functional looping construct ** `loop` defines bindings ** `recur` re-"
-"executes `loop` with new bindings"
+msgid "`recur` re-executes `loop` with new bindings"
 msgstr ""
 
 #. type: Plain text
@@ -607,15 +591,28 @@ msgid "`recur` for recursion"
 msgstr ""
 
 #. type: Plain text
+#: en/content/guides/learn/flow.adoc:277
+msgid "`recur` must be in \"tail position\""
+msgstr ""
+
+#. type: Plain text
 #: en/content/guides/learn/flow.adoc:278
-msgid "`recur` must be in \"tail position\" ** The last expression in a branch"
+msgid "The last expression in a branch"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:279
+msgid "`recur` must provide values for all bound symbols by position"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/learn/flow.adoc:280
+msgid "Loop bindings"
 msgstr ""
 
 #. type: Plain text
 #: en/content/guides/learn/flow.adoc:281
-msgid ""
-"`recur` must provide values for all bound symbols by position ** Loop "
-"bindings ** defn/fn arguments"
+msgid "defn/fn arguments"
 msgstr ""
 
 #. type: Plain text
@@ -673,9 +670,13 @@ msgid "`ex-info` takes a message and a map"
 msgstr ""
 
 #. type: Plain text
+#: en/content/guides/learn/flow.adoc:312
+msgid "`ex-data` gets the map back out"
+msgstr ""
+
+#. type: Plain text
 #: en/content/guides/learn/flow.adoc:313
-msgid ""
-"`ex-data` gets the map back out ** Or `nil` if not created with `ex-info`"
+msgid "Or `nil` if not created with `ex-info`"
 msgstr ""
 
 #. type: delimited block -

--- a/i18n/pot/content/guides/learn/functions/original.pot
+++ b/i18n/pot/content/guides/learn/functions/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,40 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/reference/java_interop.adoc:1
@@ -644,13 +610,16 @@ msgid ""
 "Below is a summary of calling conventions for calling into Java from Clojure:"
 msgstr ""
 
-#. type: Plain text
-#: en/content/guides/learn/functions.adoc:283
+#. type: Table
+#: en/content/guides/learn/functions.adoc:282
+#, no-wrap
 msgid ""
-"|=== | Task | Java | Clojure | |Instantiation| `new Widget(\"foo\")` | "
-"`(Widget. \"foo\")` | |Instance method| `rnd.next()` | `(.nextInt rnd)` | |"
-"Instance field| `object.field` | `(.-field object)` | |Static method| `Math."
-"sqrt(25)` | `(Math/sqrt 25)` | |Static field| `Math.PI` | `Math/PI` | |==="
+"| Task | Java | Clojure |\n"
+"|Instantiation| `new Widget(\"foo\")` | `(Widget. \"foo\")` | \n"
+"|Instance method| `rnd.next()` | `(.nextInt rnd)` |\n"
+"|Instance field| `object.field` | `(.-field object)` |\n"
+"|Static method| `Math.sqrt(25)` | `(Math/sqrt 25)` |\n"
+"|Static field| `Math.PI` | `Math/PI` |\n"
 msgstr ""
 
 #. type: Title ===

--- a/i18n/pot/content/guides/learn/hashed_colls/original.pot
+++ b/i18n/pot/content/guides/learn/hashed_colls/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,40 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ====
 #: en/content/reference/reader.adoc:57

--- a/i18n/pot/content/guides/learn/sequential_colls/original.pot
+++ b/i18n/pot/content/guides/learn/sequential_colls/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,40 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:49 en/content/community/editing.adoc:172

--- a/i18n/pot/content/guides/learn/syntax/original.pot
+++ b/i18n/pot/content/guides/learn/syntax/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,40 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/reference/reader.adoc:31 en/content/guides/learn/syntax.adoc:15
@@ -782,11 +748,13 @@ msgid ""
 "out values. Clojure provides several functions for printing values:"
 msgstr ""
 
-#. type: Plain text
-#: en/content/guides/learn/syntax.adoc:320
+#. type: Table
+#: en/content/guides/learn/syntax.adoc:319
+#, no-wrap
 msgid ""
-"|=== | | Human-Readable | Machine-Readable | |With newline| println | prn | |"
-"Without newline | print | pr | |==="
+"| | Human-Readable | Machine-Readable |\n"
+"|With newline| println | prn | \n"
+"|Without newline | print | pr |\n"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/guides/reader_conditionals/original.pot
+++ b/i18n/pot/content/guides/reader_conditionals/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,40 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Plain text
 #: en/content/reference/namespaces.adoc:1

--- a/i18n/pot/content/guides/repl/annex_troubleshooting/original.pot
+++ b/i18n/pot/content/guides/repl/annex_troubleshooting/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title =
 #: en/content/guides/repl/annex_troubleshooting.adoc:1

--- a/i18n/pot/content/guides/repl/basic_usage/original.pot
+++ b/i18n/pot/content/guides/repl/basic_usage/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/guides/deps_and_cli.adoc:17

--- a/i18n/pot/content/guides/repl/data_visualization_at_the_repl/original.pot
+++ b/i18n/pot/content/guides/repl/data_visualization_at_the_repl/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Plain text
 #: en/content/guides/repl/annex_troubleshooting.adoc:4

--- a/i18n/pot/content/guides/repl/enhancing_your_repl_workflow/original.pot
+++ b/i18n/pot/content/guides/repl/enhancing_your_repl_workflow/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Plain text
 #: en/content/guides/repl/annex_troubleshooting.adoc:4

--- a/i18n/pot/content/guides/repl/introduction/original.pot
+++ b/i18n/pot/content/guides/repl/introduction/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Plain text
 #: en/content/guides/repl/annex_troubleshooting.adoc:4

--- a/i18n/pot/content/guides/repl/launching_a_basic_repl/original.pot
+++ b/i18n/pot/content/guides/repl/launching_a_basic_repl/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ===
 #: en/content/community/libraries.adoc:18

--- a/i18n/pot/content/guides/repl/navigating_namespaces/original.pot
+++ b/i18n/pot/content/guides/repl/navigating_namespaces/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Plain text
 #: en/content/guides/repl/annex_troubleshooting.adoc:4
@@ -477,7 +434,7 @@ msgstr ""
 #. type: Plain text
 #: en/content/guides/repl/navigating_namespaces.adoc:261
 msgid ""
-"---- ;; ----------------------------------------------- ;; src/myproject/"
+"  ;; ----------------------------------------------- ;; src/myproject/"
 "welcome.clj (ns myproject.welcome"
 msgstr ""
 
@@ -559,7 +516,7 @@ msgstr ""
 #. type: Plain text
 #: en/content/guides/repl/navigating_namespaces.adoc:307
 msgid ""
-"---- $ clj ## APPROACH 2: requiring myproject.welcome, which itself requires "
+"  $ clj ## APPROACH 2: requiring myproject.welcome, which itself requires "
 "myproject.person-names Clojure 1.9.0 user=> (require '[myproject.welcome])  "
 "nil"
 msgstr ""

--- a/i18n/pot/content/guides/spec/original.pot
+++ b/i18n/pot/content/guides/spec/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,34 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ====
 #: en/content/reference/sequences.adoc:1 en/content/guides/spec.adoc:513
@@ -1142,25 +1114,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/guides/spec.adoc:489
+msgid "Regular expression - `(s/cat :x double? :y double? :z double?)`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/spec.adoc:490
+msgid "Allows for matching nested structure (not needed here)"
+msgstr ""
+
+#. type: Plain text
 #: en/content/guides/spec.adoc:491
-msgid ""
-"Regular expression - `(s/cat :x double? :y double? :z double?)` ** Allows "
-"for matching nested structure (not needed here)  ** Conforms to map with "
-"named keys based on the `cat` tags"
+msgid "Conforms to map with named keys based on the `cat` tags"
 msgstr ""
 
 #. type: Plain text
-#: en/content/guides/spec.adoc:494
-msgid ""
-"Collection - `(s/coll-of double?)` ** Designed for arbitrary size homogenous "
-"collections ** Conforms to a vector of the values"
+#: en/content/guides/spec.adoc:492
+msgid "Collection - `(s/coll-of double?)`"
 msgstr ""
 
 #. type: Plain text
-#: en/content/guides/spec.adoc:497
-msgid ""
-"Tuple - `(s/tuple double? double? double?)` ** Designed for fixed size with "
-"known positional \"fields\" ** Conforms to a vector of the values"
+#: en/content/guides/spec.adoc:493
+msgid "Designed for arbitrary size homogenous collections"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/spec.adoc:494 en/content/guides/spec.adoc:497
+msgid "Conforms to a vector of the values"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/spec.adoc:495
+msgid "Tuple - `(s/tuple double? double? double?)`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/guides/spec.adoc:496
+msgid "Designed for fixed size with known positional \"fields\""
 msgstr ""
 
 #. type: Plain text
@@ -2569,7 +2559,8 @@ msgid "(require '[clojure.spec.test.alpha :as stest])"
 msgstr ""
 
 #. type: Plain text
-#: en/content/guides/spec.adoc:1199 en/content/about/spec.adoc:100
+#: en/content/guides/spec.adoc:1199
+#: en/content/news/2017/12/08/clojure19.adoc:18 en/content/about/spec.adoc:100
 #, no-wrap
 msgid "Instrumentation"
 msgstr ""

--- a/i18n/pot/content/guides/weird_characters/original.pot
+++ b/i18n/pot/content/guides/weird_characters/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,33 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:81

--- a/i18n/pot/content/reference/agents/original.pot
+++ b/i18n/pot/content/reference/agents/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,33 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ==

--- a/i18n/pot/content/reference/compilation/original.pot
+++ b/i18n/pot/content/reference/compilation/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-06-01 09:26+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,32 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title =
@@ -137,12 +111,17 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/compilation.adoc:32
+#: en/content/reference/compilation.adoc:31
 msgid ""
 "The static initializer for a loader class produces the same effects as does "
-"loading its source file ** You generally shouldn't need to use these classes "
-"directly, as use, require and load will choose between them and more recent "
-"source"
+"loading its source file"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/compilation.adoc:32
+msgid ""
+"You generally shouldn't need to use these classes directly, as use, require "
+"and load will choose between them and more recent source"
 msgstr ""
 
 #. type: Plain text
@@ -206,10 +185,15 @@ msgid "Controlling the mapping to an implementing namespace"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/compilation.adoc:44
+msgid "Exposing inherited protected members"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/compilation.adoc:45
 msgid ""
-"Exposing inherited protected members ** Generating more than one named class "
-"from a single file, with implementations in one or more namespaces"
+"Generating more than one named class from a single file, with "
+"implementations in one or more namespaces"
 msgstr ""
 
 #. type: Plain text
@@ -244,10 +228,13 @@ msgid "Naming the generated interface"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/compilation.adoc:50
+msgid "Specifying any superintefaces"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/compilation.adoc:51
-msgid ""
-"Specifying any superintefaces ** Declaring the signatures of interface "
-"methods"
+msgid "Declaring the signatures of interface methods"
 msgstr ""
 
 #. type: Title ==
@@ -280,10 +267,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/compilation.adoc:58
+msgid "For each gen-class:"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/compilation.adoc:59
-msgid ""
-"For each gen-class: ** A stub classfile will be produced with the specified "
-"name"
+msgid "A stub classfile will be produced with the specified name"
 msgstr ""
 
 #. type: Title ==

--- a/i18n/pot/content/reference/data_structures/original.pot
+++ b/i18n/pot/content/reference/data_structures/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,33 +46,6 @@ msgstr ""
 msgid "Rich Hickey 2015-01-01"
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
-
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73
 #: en/content/reference/namespaces.adoc:24
@@ -104,6 +77,7 @@ msgstr ""
 #. type: Title ==
 #: en/content/reference/reader.adoc:100
 #: en/content/reference/data_structures.adoc:235
+#: en/content/guides/learn/hashed_colls.adoc:19
 #, no-wrap
 msgid "Sets"
 msgstr ""
@@ -143,12 +117,38 @@ msgid "They provide good hash values"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/data_structures.adoc:24
+msgid "In addition, the collections:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:25
+msgid "Are manipulated via interfaces."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:26
+msgid "Support sequencing"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:27
+msgid "Support persistent manipulation."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:28
+msgid "Support metadata"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/data_structures.adoc:29
+msgid "Implement java.lang.Iterable"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/data_structures.adoc:30
-msgid ""
-"In addition, the collections: ** Are manipulated via interfaces.  ** Support "
-"sequencing ** Support persistent manipulation.  ** Support metadata ** "
-"Implement java.lang.Iterable ** Implement the non-optional (read-only) "
-"portion of java.util.Collection"
+msgid "Implement the non-optional (read-only) portion of java.util.Collection"
 msgstr ""
 
 #. type: Title ==
@@ -247,14 +247,17 @@ msgid ""
 "and M respectively."
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/data_structures.adoc:69
+#. type: Table
+#: en/content/reference/data_structures.adoc:68
+#, no-wrap
 msgid ""
-"|=== | Example expression | Return value | `(== 1 1.0 1M)` | `true` | `(/ 2 "
-"3)` | `2/3` | `(/ 2.0 3)` | `0.6666666666666666` | `(map #(Math/abs %) "
-"(range -3 3))` | `(3 2 1 0 1 2)` | `(class 36786883868216818816N)` | "
-"`clojure.lang.BigInt` | `(class 3.14159265358M)` | `java.math.BigDecimal` |"
-"==="
+"| Example expression | Return value\n"
+"| `(== 1 1.0 1M)` | `true`\n"
+"| `(/ 2 3)` | `2/3`\n"
+"| `(/ 2.0 3)` | `0.6666666666666666`\n"
+"| `(map #(Math/abs %) (range -3 3))` | `(3 2 1 0 1 2)`\n"
+"| `(class 36786883868216818816N)` | `clojure.lang.BigInt`\n"
+"| `(class 3.14159265358M)` | `java.math.BigDecimal`\n"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/datatypes/original.pot
+++ b/i18n/pot/content/reference/datatypes/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,33 +46,6 @@ msgstr ""
 msgid "Rich Hickey 2015-01-01"
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
-
 #. type: Title ==
 #: en/content/reference/protocols.adoc:16
 #: en/content/reference/datatypes.adoc:17
@@ -103,8 +76,8 @@ msgid "Basics"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/special_forms.adoc:176
-#: en/content/reference/datatypes.adoc:115 en/content/guides/faq.adoc:177
+#: en/content/reference/special_forms.adoc:182
+#: en/content/reference/datatypes.adoc:115 en/content/guides/faq.adoc:184
 msgid "Example:"
 msgstr ""
 
@@ -176,12 +149,21 @@ msgid "because they generate a named class, it has an accessible constructor"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/datatypes.adoc:36
+#: en/content/reference/datatypes.adoc:34
+msgid "fields can have type hints, and can be primitive"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:35
 msgid ""
-"fields can have type hints, and can be primitive ** note that currently a "
-"type hint of a non-primitive type will not be used to constrain the field "
-"type nor the constructor arg, but will be used to optimize its use in the "
-"class methods ** constraining the field type and constructor arg is planned"
+"note that currently a type hint of a non-primitive type will not be used to "
+"constrain the field type nor the constructor arg, but will be used to "
+"optimize its use in the class methods"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:36
+msgid "constraining the field type and constructor arg is planned"
 msgstr ""
 
 #. type: Plain text
@@ -191,12 +173,28 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/datatypes.adoc:41
+#: en/content/reference/datatypes.adoc:38
 msgid ""
 "deftype/defrecord can be written with a special reader syntax #my.thing[1 2 "
-"3] where: ** each element in the vector form is passed to the deftype/"
-"defrecord's constructor un-evaluated ** the deftype/defrecord name must be "
-"fully qualified ** only available in Clojure versions later than 1.3"
+"3] where:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:39
+msgid ""
+"each element in the vector form is passed to the deftype/defrecord's "
+"constructor un-evaluated"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:40
+msgid "the deftype/defrecord name must be fully qualified"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:41
+#: en/content/reference/datatypes.adoc:62
+msgid "only available in Clojure versions later than 1.3"
 msgstr ""
 
 #. type: Plain text
@@ -223,12 +221,41 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/datatypes.adoc:54
+#: en/content/reference/datatypes.adoc:48
 msgid ""
-"defrecord provides a complete implementation of a persistent map, including: "
-"** value-based equality and hashCode ** metadata support ** associative "
-"support ** keyword accessors for fields ** extensible fields (you can assoc "
-"keys not supplied with the defrecord definition)  ** etc"
+"defrecord provides a complete implementation of a persistent map, including:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:49
+msgid "value-based equality and hashCode"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:50
+msgid "metadata support"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:51
+msgid "associative support"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:52
+msgid "keyword accessors for fields"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:53
+msgid ""
+"extensible fields (you can assoc keys not supplied with the defrecord "
+"definition)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:54
+msgid "etc"
 msgstr ""
 
 #. type: Plain text
@@ -237,15 +264,37 @@ msgid "deftype supports mutable fields, defrecord does not"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/datatypes.adoc:62
+#: en/content/reference/datatypes.adoc:56
 msgid ""
 "defrecord supports an additional reader form of #my.record{:a 1, :b 2} "
-"taking a map that initializes a defrecord according to: ** the defrecord "
-"name must be fully qualified ** the elements in the map are un-evaluated ** "
-"existing defrecord fields take the keyed values ** defrecord fields without "
-"keyed values in the literal map are initialized to nil ** additional keyed "
-"values are allowed and added to the defrecord ** only available in Clojure "
-"versions later than 1.3"
+"taking a map that initializes a defrecord according to:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:57
+msgid "the defrecord name must be fully qualified"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:58
+msgid "the elements in the map are un-evaluated"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:59
+msgid "existing defrecord fields take the keyed values"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:60
+msgid ""
+"defrecord fields without keyed values in the literal map are initialized to "
+"nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:61
+msgid "additional keyed values are allowed and added to the defrecord"
 msgstr ""
 
 #. type: Plain text
@@ -325,36 +374,53 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/datatypes.adoc:79
+msgid "Concrete derivation is bad"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/datatypes.adoc:80
-msgid ""
-"Concrete derivation is bad ** you cannot derive datatypes from concrete "
-"classes, only interfaces"
+msgid "you cannot derive datatypes from concrete classes, only interfaces"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:81
+msgid "You should always program to protocols or interfaces"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:82
-msgid ""
-"You should always program to protocols or interfaces ** datatypes cannot "
-"expose methods not in their protocols or interfaces"
+msgid "datatypes cannot expose methods not in their protocols or interfaces"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:83
+msgid "Immutability should be the default"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:84
-msgid ""
-"Immutability should be the default ** and is the only option for records"
+msgid "and is the only option for records"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:85
+msgid "Encapsulation of information is folly"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:86
-msgid ""
-"Encapsulation of information is folly ** fields are public, use protocols/"
-"interfaces to avoid dependencies"
+msgid "fields are public, use protocols/interfaces to avoid dependencies"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/datatypes.adoc:87
+msgid "Tying polymorphism to inheritance is bad"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/datatypes.adoc:88
-msgid ""
-"Tying polymorphism to inheritance is bad ** protocols free you from that"
+msgid "protocols free you from that"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/deps_and_cli/original.pot
+++ b/i18n/pot/content/reference/deps_and_cli/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,40 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/reference/deps_and_cli.adoc:1 en/content/guides/faq.adoc:203
@@ -391,44 +357,143 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:135
+msgid "Installation directory"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:136
+msgid "Created during installation"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:137
+#: en/content/reference/deps_and_cli.adoc:149
+#: en/content/reference/deps_and_cli.adoc:158
+msgid "Contents:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:138
+msgid "`bin/clojure` - main tool"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:139
+msgid "`bin/clj` - wrapper for interactive repl use (uses `rlwrap`)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:140
+msgid ""
+"`deps.edn` - install level deps.edn file, with some default deps (Clojure, "
+"etc) and provider config"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:141
+msgid ""
+"`example-deps.edn` - commented example that gets copied to `<config_dir>/"
+"deps.edn`"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:142
 msgid ""
-"Installation directory ** Created during installation ** Contents: *** `bin/"
-"clojure` - main tool *** `bin/clj` - wrapper for interactive repl use (uses "
-"`rlwrap`)  *** `deps.edn` - install level deps.edn file, with some default "
-"deps (Clojure, etc) and provider config *** `example-deps.edn` - commented "
-"example that gets copied to `<config_dir>/deps.edn` *** `libexec/clojure-"
-"tools-X.Y.Z.jar` - uberjar invoked by `clojure` to construct classpaths"
+"`libexec/clojure-tools-X.Y.Z.jar` - uberjar invoked by `clojure` to "
+"construct classpaths"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:143
+msgid "Config directory"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:144
+msgid ""
+"Holds a deps.edn file that persists across tool upgrades and affects all "
+"projects"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:145
+msgid "Locations used in this order:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:146
+msgid "If `$CLJ_CONFIG` is set, then use `$CLJ_CONFIG` (explicit override)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:147
+msgid ""
+"If `$XDG_CONFIG_HOME` is set, then use `$XDG_CONFIG_HOME/clojure` "
+"(Freedesktop conventions)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:148
+msgid "Else use `$HOME/.clojure` (most common)"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:150
 msgid ""
-"Config directory ** Holds a deps.edn file that persists across tool upgrades "
-"and affects all projects ** Locations used in this order: *** If `"
-"$CLJ_CONFIG` is set, then use `$CLJ_CONFIG` (explicit override)  *** If `"
-"$XDG_CONFIG_HOME` is set, then use `$XDG_CONFIG_HOME/clojure` (Freedesktop "
-"conventions)  *** Else use `$HOME/.clojure` (most common)  ** Contents: *** "
 "`deps.edn` - user deps file, defines default Clojure version and provider "
 "defaults"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/deps_and_cli.adoc:155
+#: en/content/reference/deps_and_cli.adoc:151
+msgid "Cache directory"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:152
 msgid ""
-"Cache directory ** Lazily created when `clojure` is invoked without a local "
-"`deps.edn` file. Locations used in this order: *** If `$CLJ_CACHE` is set, "
-"then use `$CLJ_CACHE` (explicit override)  *** If `$XDG_CACHE_HOME` is set, "
-"then use `$XDG_CACHE_HOME/clojure` (Freedesktop conventions)  *** Else use "
-"`config_dir/.cpcache` (most common)"
+"Lazily created when `clojure` is invoked without a local `deps.edn` file. "
+"Locations used in this order:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:153
+msgid "If `$CLJ_CACHE` is set, then use `$CLJ_CACHE` (explicit override)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:154
+msgid ""
+"If `$XDG_CACHE_HOME` is set, then use `$XDG_CACHE_HOME/clojure` (Freedesktop "
+"conventions)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:155
+msgid "Else use `config_dir/.cpcache` (most common)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:156
+msgid "Project directory"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:157
+msgid "The current directory"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:159
+msgid "`deps.edn` - optional project deps"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:160
 msgid ""
-"Project directory ** The current directory ** Contents: *** `deps.edn` - "
-"optional project deps *** `.cpcache` - project cache directory, same as the "
-"user-level cache directory, created if there is a `deps.edn`"
+"`.cpcache` - project cache directory, same as the user-level cache "
+"directory, created if there is a `deps.edn`"
 msgstr ""
 
 #. type: Title ===
@@ -506,19 +571,39 @@ msgid "Coordinates can take several forms depending on the coordinate type:"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:182
+msgid "Maven coordinate: `{:mvn/version \"1.2.3\"}`"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:183
+msgid "Other optional keys: `:classifier`, `:extension`, `:exclusions`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:184
+msgid "Local project coordinate: `{:local/root \"/path/to/project\"}`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:185
+msgid "Optional key `:deps/manifest`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:186
+msgid "Specifies the project manifest type"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:187
 msgid ""
-"Maven coordinate: `{:mvn/version \"1.2.3\"}` ** Other optional keys: `:"
-"classifier`, `:extension`, `:exclusions`"
+"Default is to auto-detect the project type (such as `:deps`, `:lein`, `:pom`)"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:188
-msgid ""
-"Local project coordinate: `{:local/root \"/path/to/project\"}` ** Optional "
-"key `:deps/manifest` *** Specifies the project manifest type *** Default is "
-"to auto-detect the project type (such as `:deps`, `:lein`, `:pom`)  *** "
-"Currently only `:deps` is supported"
+msgid "Currently only `:deps` is supported"
 msgstr ""
 
 #. type: Plain text
@@ -527,14 +612,39 @@ msgid "Local jar: `{:local/root \"/path/to/file.jar\"}`"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/deps_and_cli.adoc:195
+#: en/content/reference/deps_and_cli.adoc:190
 msgid ""
 "Git coordinate: `{:git/url \"https://github.com/user/project.git\", :sha "
-"\"sha\", :tag \"tag\"}` ** The `:git/url` can be one of the following: *** "
-"https - secure anonymous access to public repos *** ssh or user@host form "
-"urls (including GitHub) - ssh-based access (see Git configuration section)  "
-"** The `:sha` attribute should indicate the full commit sha ** The `:tag` "
-"attribute is optional but can be used to indicate the semantics of the sha"
+"\"sha\", :tag \"tag\"}`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:191
+msgid "The `:git/url` can be one of the following:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:192
+msgid "https - secure anonymous access to public repos"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:193
+msgid ""
+"ssh or user@host form urls (including GitHub) - ssh-based access (see Git "
+"configuration section)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:194
+msgid "The `:sha` attribute should indicate the full commit sha"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:195
+msgid ""
+"The `:tag` attribute is optional but can be used to indicate the semantics "
+"of the sha"
 msgstr ""
 
 #. type: delimited block -
@@ -578,7 +688,7 @@ msgstr ""
 
 #. type: Title ==
 #: en/content/reference/deps_and_cli.adoc:216
-#: en/content/reference/java_interop.adoc:271
+#: en/content/reference/java_interop.adoc:275
 #, no-wrap
 msgid "Aliases"
 msgstr ""
@@ -591,51 +701,123 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:221
+msgid ""
+"-R - `resolve-deps` aliases are modifications applied during `resolve-deps`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:222
+#: en/content/reference/deps_and_cli.adoc:228
+#: en/content/reference/deps_and_cli.adoc:233
+#: en/content/reference/deps_and_cli.adoc:238
+msgid "Allowed keys in these aliases are:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:223
+msgid ""
+"`:extra-deps` - a deps map from lib to coordinate of deps to add to the deps"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:224
+msgid ""
+"`:override-deps` - a deps map from lib to coordinate of override versions to "
+"use"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:225
+msgid ""
+"`:default-deps` - a deps map from lib to coordinate of versions to use if "
+"none is found"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:226
 msgid ""
-"-R - `resolve-deps` aliases are modifications applied during `resolve-deps` "
-"** Allowed keys in these aliases are: *** `:extra-deps` - a deps map from "
-"lib to coordinate of deps to add to the deps *** `:override-deps` - a deps "
-"map from lib to coordinate of override versions to use *** `:default-deps` - "
-"a deps map from lib to coordinate of versions to use if none is found ** If "
-"multiple -R alias maps are activated, all of these are merge-with merged"
+"If multiple -R alias maps are activated, all of these are merge-with merged"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:227
+msgid ""
+"-C - `make-classpath` aliases are modifications applied during `make-"
+"classpath`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:229
+msgid "`:extra-paths` - a collection of string paths to add to `:paths`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:230
+msgid ""
+"`:classpath-overrides` - a map of lib to string path to replace the location "
+"of the lib"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:231
 msgid ""
-"-C - `make-classpath` aliases are modifications applied during `make-"
-"classpath` ** Allowed keys in these aliases are: *** `:extra-paths` - a "
-"collection of string paths to add to `:paths` *** `:classpath-overrides` - a "
-"map of lib to string path to replace the location of the lib *** If multiple "
-"-C alias maps are activated, `:extra-paths` concatenate and `:classpath-"
-"overrides` merge-with merge"
+"If multiple -C alias maps are activated, `:extra-paths` concatenate and `:"
+"classpath-overrides` merge-with merge"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:232
+msgid "-O - JVM option aliases"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:234
+msgid "`:jvm-opts` - a collection of string JVM options"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:235
+msgid "If multiple -O alias maps are activated, `:jvm-opts` concatenate"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:236
 msgid ""
-"-O - JVM option aliases ** Allowed keys in these aliases are: *** `:jvm-"
-"opts` - a collection of string JVM options ** If multiple -O alias maps are "
-"activated, `:jvm-opts` concatenate ** If -J JVM options are also specified "
-"on the command line, they are concatenated after the alias options"
+"If -J JVM options are also specified on the command line, they are "
+"concatenated after the alias options"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:237
+msgid "-M - clojure.main option aliases"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:239
+msgid "`:main-opts` - a collection of clojure.main options"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:240
+msgid "If multiple -M alias maps are activated, only the last one will be used"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:241
 msgid ""
-"-M - clojure.main option aliases ** Allowed keys in these aliases are: *** `:"
-"main-opts` - a collection of clojure.main options ** If multiple -M alias "
-"maps are activated, only the last one will be used ** If command line "
-"clojure.main arguments are supplied on the command line, they are "
-"concatenated after the last main alias map"
+"If command line clojure.main arguments are supplied on the command line, "
+"they are concatenated after the last main alias map"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:242
+msgid "-A - applies across all alias types"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:243
-msgid ""
-"-A - applies across all alias types ** These aliases support ALL alias keys "
-"above and all will be applied"
+msgid "These aliases support ALL alias keys above and all will be applied"
 msgstr ""
 
 #. type: Plain text
@@ -967,21 +1149,58 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:385
+msgid "Compute the deps map"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:386
+msgid "Read the deps.edn configuration file in the following locations:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:387
+msgid "Install directory (unless -Srepro)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:388
+msgid "Config directory (if it exists and unless -Srepro)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:389
+msgid "Current directory (if it exists)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:390
+msgid "-Sdeps data (if it exists)"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:391
 msgid ""
-"Compute the deps map ** Read the deps.edn configuration file in the "
-"following locations: *** Install directory (unless -Srepro)  *** Config "
-"directory (if it exists and unless -Srepro)  *** Current directory (if it "
-"exists)  *** -Sdeps data (if it exists)  ** Combine the deps.edn maps in "
-"that order with `merge-with merge` (except for :paths where last wins)"
+"Combine the deps.edn maps in that order with `merge-with merge` (except for :"
+"paths where last wins)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:392
+msgid "Compute the resolve-deps args"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:393
+msgid ""
+"If `-R` specifies one or more aliases, find each alias in the deps map `:"
+"aliases`"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/deps_and_cli.adoc:394
 msgid ""
-"Compute the resolve-deps args ** If `-R` specifies one or more aliases, find "
-"each alias in the deps map `:aliases` ** `merge-with` `merge` the alias maps "
-"- the result is the resolve-args map"
+"`merge-with` `merge` the alias maps - the result is the resolve-args map"
 msgstr ""
 
 #. type: Plain text
@@ -990,11 +1209,20 @@ msgid "Invoke `resolve-deps` with deps map and resolve-args map"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/deps_and_cli.adoc:398
+#: en/content/reference/deps_and_cli.adoc:396
+msgid "Compute the classpath-overrides map"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:397
 msgid ""
-"Compute the classpath-overrides map ** If `-C` specifies one or more "
-"aliases, find each alias in the deps map `:aliases` ** `merge` the classpath-"
-"override alias maps"
+"If `-C` specifies one or more aliases, find each alias in the deps map `:"
+"aliases`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/deps_and_cli.adoc:398
+msgid "`merge` the classpath-override alias maps"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/java_interop/original.pot
+++ b/i18n/pot/content/reference/java_interop/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Plain text
 #: en/content/reference/metadata.adoc:23 en/content/reference/metadata.adoc:29

--- a/i18n/pot/content/reference/lazy/original.pot
+++ b/i18n/pot/content/reference/lazy/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,57 +17,33 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4
-#: en/content/reference/metadata.adoc:4 en/content/reference/evaluation.adoc:4
-#: en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4
+#: en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4
+#: en/content/reference/transients.adoc:4
 #: en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4
 #: en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4
+#: en/content/reference/transducers.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4
+#: en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4
 #: en/content/reference/data_structures.adoc:4
-#: en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4
-#: en/content/reference/lisps.adoc:4 en/content/reference/lazy.adoc:4
-#: en/content/reference/repl_and_main.adoc:4
-#: en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4
-#: en/content/reference/multimethods.adoc:4 en/content/search.adoc:4
-#: en/content/about/clojureclr.adoc:4
-#: en/content/about/functional_programming.adoc:4 en/content/about/lisp.adoc:4
-#: en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4
-#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4
-#: en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4
-#: en/content/privacy.adoc:4 en/content/community/swag.adoc:4
-#: en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
+#: en/content/reference/atoms.adoc:4 en/content/reference/repl_and_main.adoc:4
+#: en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4
 #: en/content/community/downloads_older.adoc:4
-#: en/content/community/libraries.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4
+#: en/content/404.adoc:4 en/content/privacy.adoc:4 en/content/search.adoc:4
+#: en/content/about/spec.adoc:4 en/content/about/concurrent_programming.adoc:4
+#: en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4
+#: en/content/about/features.adoc:4 en/content/about/rationale.adoc:4
+#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4
+#: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/sequences.adoc:15 en/content/reference/metadata.adoc:15
-#: en/content/reference/reader.adoc:13 en/content/reference/transients.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/datatypes.adoc:16 en/content/reference/agents.adoc:16
-#: en/content/reference/protocols.adoc:15 en/content/reference/reducers.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/transducers.adoc:15 en/content/reference/vars.adoc:16
-#: en/content/reference/namespaces.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/multimethods.adoc:15
-#: en/content/about/functional_programming.adoc:15
-#: en/content/about/dynamic.adoc:16 en/content/about/spec.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title =
@@ -91,26 +67,53 @@ msgid "In working on streams a few things became evident:"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/lazy.adoc:18
+msgid "stream code is ugly and imperative"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/lazy.adoc:19
-msgid ""
-"stream code is ugly and imperative ** even when made safe, still ugly, "
-"stateful"
+msgid "even when made safe, still ugly, stateful"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:20
+msgid "streams support full laziness"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:21
-msgid "streams support full laziness ** this ends up being extremely nice"
+msgid "this ends up being extremely nice"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:22
+msgid ""
+"Integrating streams transparently (i.e. not having both map and map-stream) "
+"would require a change, to relax the contract of the core sequence functions "
+"(map, filter etc)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:23
+msgid ""
+"If I am going to do that, could I achieve the same full laziness while "
+"keeping the beautiful recursive style of Clojure?"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:24
+msgid "while being substantially compatible with existing code"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:25
+msgid "Yes!"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:26
-msgid ""
-"Integrating streams transparently (i.e. not having both map and map-stream) "
-"would require a change, to relax the contract of the core sequence functions "
-"(map, filter etc)  ** If I am going to do that, could I achieve the same "
-"full laziness while keeping the beautiful recursive style of Clojure? *** "
-"while being substantially compatible with existing code *** Yes! **** but - "
-"ideally some names should change"
+msgid "but - ideally some names should change"
 msgstr ""
 
 #. type: Title ===
@@ -135,13 +138,34 @@ msgid "A seq is like a logical cursor"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/lazy.adoc:33
+msgid "rest is fundamentally eager"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:34
+msgid "returns another seq or nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:35
+msgid ""
+"needs to determine if there is any more in order to determine if return "
+"value is nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:36
+msgid ""
+"lazy-cons can delay the calculation of first/rest, but not the determination "
+"if there is a rest"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/lazy.adoc:37
 msgid ""
-"rest is fundamentally eager ** returns another seq or nil ** needs to "
-"determine if there is any more in order to determine if return value is nil "
-"** lazy-cons can delay the calculation of first/rest, but not the "
-"determination if there is a rest *** determining that often requires "
-"'pulling' on an inner seq, reducing effective laziness"
+"determining that often requires 'pulling' on an inner seq, reducing "
+"effective laziness"
 msgstr ""
 
 #. type: Plain text
@@ -163,54 +187,126 @@ msgid "Enhancing the seq model - a third operation on seqs - 'next'"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:50
+#: en/content/reference/lazy.adoc:44
 msgid ""
-"_**Changed:**_ (*rest* aseq) - returns a possibly empty seq, _never nil_ ** "
-"calls seq on arg if not already a seq ** the returned seq may be empty *** "
-"will print (), but not a single sentinel object ** never returns nil *** "
-"currently not enforced on 3rd-party seqs ** a (possibly) delayed path to the "
-"remaining items, if any"
+"_**Changed:**_ (*rest* aseq) - returns a possibly empty seq, _never nil_"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:45 en/content/reference/lazy.adoc:58
+#: en/content/reference/lazy.adoc:63
+msgid "calls seq on arg if not already a seq"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:46
+msgid "the returned seq may be empty"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:47
+msgid "will print (), but not a single sentinel object"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:48
+msgid "never returns nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:49
+msgid "currently not enforced on 3rd-party seqs"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:50
+msgid "a (possibly) delayed path to the remaining items, if any"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:51
+msgid "_**Changed**_: seqs can be empty"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:52
-msgid "_**Changed**_: seqs can be empty ** always an ISeq"
+msgid "always an ISeq"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:56
-msgid ""
-"_**Changed**_: the *seq* function - no longer an identity for ISeqs ** still "
-"returns either a seq or nil ** (seq aseq) -> ___**no longer an identity, if "
-"aseq empty returns nil**___ ** still works on nil"
+#: en/content/reference/lazy.adoc:53
+msgid "_**Changed**_: the *seq* function - no longer an identity for ISeqs"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:60
+#: en/content/reference/lazy.adoc:54
+msgid "still returns either a seq or nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:55
 msgid ""
-"the *first* function doesn't change ** calls seq on arg if not already a seq "
-"** returns first item ** still works on nil"
+"(seq aseq) -> ___**no longer an identity, if aseq empty returns nil**___"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:56 en/content/reference/lazy.adoc:60
+msgid "still works on nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:57
+msgid "the *first* function doesn't change"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:59
+msgid "returns first item"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:61
+msgid "_**New**:_ the *next* function does what *rest* used to do"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:62
+msgid "returns the next seq, if any, else nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:64
+msgid "(next aseq) === (seq (rest aseq))"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:65
-msgid ""
-"_**New**:_ the *next* function does what *rest* used to do ** returns the "
-"next seq, if any, else nil ** calls seq on arg if not already a seq ** (next "
-"aseq) === (seq (rest aseq))  ** works on nil"
+msgid "works on nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:66
+msgid "_**Changed**_: seq?"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:67
-msgid "_**Changed**_: seq? ** (seq? ()) -> true"
+msgid "(seq? ()) -> true"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:68
+msgid "_**Changed:**_ Sequence fns (map, filter etc) return seqs, but not nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:69
+msgid "You'll need to call seq on their return value in order to get a seq/nil"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:70
-msgid ""
-"_**Changed:**_ Sequence fns (map, filter etc) return seqs, but not nil ** "
-"You'll need to call seq on their return value in order to get a seq/nil *** "
-"seq also serves as test for end, already idiomatic"
+msgid "seq also serves as test for end, already idiomatic"
 msgstr ""
 
 #. type: delimited block -
@@ -222,12 +318,18 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/lazy.adoc:77
+msgid "allows full laziness"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:78
+msgid "doesn't support nil punning"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/lazy.adoc:79
-#, no-wrap
-msgid ""
-"** allows full laziness\n"
-"** doesn't support nil punning\n"
-"*** since sequence fns no longer return seq/nil\n"
+msgid "since sequence fns no longer return seq/nil"
 msgstr ""
 
 #. type: Title ===
@@ -237,29 +339,80 @@ msgid "Recipe - How to write lazy sequence functions in new model"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:93
+#: en/content/reference/lazy.adoc:83
+msgid "Goodbye lazy-cons, hello lazy-seq"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:84
+msgid "lazy-cons is gone"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:85
+msgid "new laziness macro - _**lazy-seq**_"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:86
+msgid "takes a body that yields a seq, nil or anything seq-able"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:87
+msgid "returns a logical collection that implements seq by calling the body"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:88
+msgid "invokes the body only the first time seq is called on it, caches result"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:89
+msgid "will call seq on the body's return value if not already a seq or nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:90
 msgid ""
-"Goodbye lazy-cons, hello lazy-seq ** lazy-cons is gone ** new laziness macro "
-"- _**lazy-seq**_ *** takes a body that yields a seq, nil or anything seq-"
-"able *** returns a logical collection that implements seq by calling the "
-"body **** invokes the body only the first time seq is called on it, caches "
-"result **** will call seq on the body's return value if not already a seq or "
-"nil ** The net effect is the creation of a virtual collection that does no "
-"work until seq is called upon it - fully delayed ** Supports all collection "
-"ops ** Can be empty - e.g. calling seq on it can return nil *** when empty "
-"will print as ()"
+"The net effect is the creation of a virtual collection that does no work "
+"until seq is called upon it - fully delayed"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:91
+msgid "Supports all collection ops"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:92
+msgid "Can be empty - e.g. calling seq on it can return nil"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:93
+msgid "when empty will print as ()"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:94
+msgid "lazy-seq goes at top level of lazy sequence function"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:95
-msgid ""
-"lazy-seq goes at top level of lazy sequence function ** instead of nested "
-"lazy-cons"
+msgid "instead of nested lazy-cons"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:96
+msgid "inside, use a normal cons call"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:97
-msgid "inside, use a normal cons call ** won't be created until needed"
+msgid "won't be created until needed"
 msgstr ""
 
 #. type: Plain text
@@ -367,15 +520,43 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lazy.adoc:145
+#: en/content/reference/lazy.adoc:139
 msgid ""
 "Audit your code for nil-punning. The lazy branch has supports compilation in "
 "a debug mode that asserts if you try to test the truth value of a lazy "
 "sequence in a conditional, and will throw an exception if you do. Just build "
-"clojure like so: ** ant -Dclojure.assert-if-lazy-seq=true ** Then, nil puns "
-"like the following will throw exceptions: *** (when (filter neg? [1 2]) :all-"
-"pos)  *** (not (concat))  *** (if (rest (seq [])) 1 2)  ** In all cases you "
-"can fix a nil pun by wrapping the sequence with a seq call:"
+"clojure like so:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:140
+msgid "ant -Dclojure.assert-if-lazy-seq=true"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:141
+msgid "Then, nil puns like the following will throw exceptions:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:142
+msgid "(when (filter neg? [1 2]) :all-pos)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:143
+msgid "(not (concat))"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:144
+msgid "(if (rest (seq [])) 1 2)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/lazy.adoc:145
+msgid ""
+"In all cases you can fix a nil pun by wrapping the sequence with a seq call:"
 msgstr ""
 
 #. type: delimited block -
@@ -388,8 +569,8 @@ msgstr ""
 
 #. type: Plain text
 #: en/content/reference/lazy.adoc:152
-#, no-wrap
-msgid "** After you are done, rebuild without the flag, as it will slow things down.\n"
+msgid ""
+"After you are done, rebuild without the flag, as it will slow things down."
 msgstr ""
 
 #. type: Title ===

--- a/i18n/pot/content/reference/libs/original.pot
+++ b/i18n/pot/content/reference/libs/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,33 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Plain text
@@ -123,21 +96,49 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/libs.adoc:29
+#: en/content/reference/libs.adoc:25
 msgid ""
 "A lib's container is a Java resource whose classpath-relative path is "
-"derived from the lib name: ** The path is a string ** Periods in the lib "
-"name are replaced by slashes in the path ** Hyphens in the lib name are "
-"replaced by underscores in the path ** The path may end with \".class\", \"."
-"clj\", or \".cljc\" (see <<libs#order,Lib load order>> below)"
+"derived from the lib name:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:26
+msgid "The path is a string"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:27
+msgid "Periods in the lib name are replaced by slashes in the path"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:28
+msgid "Hyphens in the lib name are replaced by underscores in the path"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:29
+msgid ""
+"The path may end with \".class\", \".clj\", or \".cljc\" (see <<libs#order,"
+"Lib load order>> below)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:30
+msgid "A lib begins with an \"ns\" form that"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/libs.adoc:31
+msgid "creates the Clojure namespace that shares its name, and"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/libs.adoc:32
 msgid ""
-"A lib begins with an \"ns\" form that ** creates the Clojure namespace that "
-"shares its name, and ** declares its dependencies on Java classes, Clojure's "
-"core facilities, and/or other libs,"
+"declares its dependencies on Java classes, Clojure's core facilities, and/or "
+"other libs,"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/lisps/original.pot
+++ b/i18n/pot/content/reference/lisps/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,32 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4
-#: en/content/reference/metadata.adoc:4 en/content/reference/evaluation.adoc:4
-#: en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4
+#: en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4
+#: en/content/reference/transients.adoc:4
 #: en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4
 #: en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4
+#: en/content/reference/transducers.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4
+#: en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4
 #: en/content/reference/data_structures.adoc:4
-#: en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4
-#: en/content/reference/lisps.adoc:4 en/content/reference/lazy.adoc:4
-#: en/content/reference/repl_and_main.adoc:4
-#: en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4
-#: en/content/reference/multimethods.adoc:4 en/content/search.adoc:4
-#: en/content/about/clojureclr.adoc:4
-#: en/content/about/functional_programming.adoc:4 en/content/about/lisp.adoc:4
-#: en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4
-#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4
-#: en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4
-#: en/content/privacy.adoc:4 en/content/community/swag.adoc:4
-#: en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
+#: en/content/reference/atoms.adoc:4 en/content/reference/repl_and_main.adoc:4
+#: en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4
 #: en/content/community/downloads_older.adoc:4
-#: en/content/community/libraries.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4
+#: en/content/404.adoc:4 en/content/privacy.adoc:4 en/content/search.adoc:4
+#: en/content/about/spec.adoc:4 en/content/about/concurrent_programming.adoc:4
+#: en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4
+#: en/content/about/features.adoc:4 en/content/about/rationale.adoc:4
+#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4
+#: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
 msgstr ""
 
@@ -53,116 +53,116 @@ msgid "Differences with other Lisps"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:14
+#: en/content/reference/lisps.adoc:16
 msgid ""
 "This information is provided for programmers familiar with Common Lisp or "
 "Scheme."
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:16
+#: en/content/reference/lisps.adoc:18
 msgid "Clojure is case sensitive"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:17
+#: en/content/reference/lisps.adoc:19
 msgid "Clojure is a Lisp-1"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:18
+#: en/content/reference/lisps.adoc:20
 msgid "() is not the same as nil"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:19
+#: en/content/reference/lisps.adoc:21
 msgid "The reader is side-effect free"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:20
+#: en/content/reference/lisps.adoc:22
 msgid "Keywords are not Symbols"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:21
+#: en/content/reference/lisps.adoc:23
 msgid "Symbols are not storage locations (see Var)"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:22
+#: en/content/reference/lisps.adoc:24
 msgid "_**nil**_ is not a Symbol"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:23
+#: en/content/reference/lisps.adoc:25
 msgid "t is not syntax, use _**true**_"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:24
+#: en/content/reference/lisps.adoc:26
 msgid "The read table is currently not accessible to user programs"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:25
+#: en/content/reference/lisps.adoc:27
 msgid "_**let**_ binds sequentially"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:26
+#: en/content/reference/lisps.adoc:28
 msgid "_**do**_ is not a looping construct"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:27
+#: en/content/reference/lisps.adoc:29
 msgid "There is no tail-call optimization, use _**recur**_."
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:28
+#: en/content/reference/lisps.adoc:30
 msgid "syntax-quote does symbol resolution, so `x is not the same as 'x."
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:29
+#: en/content/reference/lisps.adoc:31
 msgid "` has auto-gensyms."
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:30
+#: en/content/reference/lisps.adoc:32
 msgid "~ is unquote ',' is whitespace"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:31
+#: en/content/reference/lisps.adoc:33
 msgid "There is reader syntax for maps, vectors, and sets"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:32
+#: en/content/reference/lisps.adoc:34
 msgid ""
 "_**cons**_, _**first**_ and _**rest**_ manipulate sequence abstractions, not "
 "concrete cons cells"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:33
+#: en/content/reference/lisps.adoc:35
 msgid "Most data structures are immutable"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:34
+#: en/content/reference/lisps.adoc:36
 msgid "lambda is _**fn**_, and supports overloading by arity"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:35
+#: en/content/reference/lisps.adoc:37
 msgid "_**pass:[=]**_ is the equality predicate"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:36
+#: en/content/reference/lisps.adoc:38
 msgid ""
 "Global Vars can be dynamically rebound (if declared dynamic) without "
 "interfering with lexical local bindings. No special declarations are "
@@ -172,7 +172,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:37
+#: en/content/reference/lisps.adoc:39
 msgid ""
 "No letrec, labels or flet - use (fn name [args]...) for self-reference, "
 "https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/"
@@ -180,28 +180,28 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:38
+#: en/content/reference/lisps.adoc:40
 msgid ""
 "In Clojure _**nil**_ means 'nothing'. It signifies the absence of a value, "
 "of any type, and is not specific to lists or sequences."
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:39
+#: en/content/reference/lisps.adoc:41
 msgid ""
 "Empty collections are distinct from _**nil**_. Clojure does not equate "
 "_**nil**_ and '()."
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:40
+#: en/content/reference/lisps.adoc:42
 msgid ""
 "_**false**_ means one of the two possible boolean values, the other being "
 "_**true**_"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:41
+#: en/content/reference/lisps.adoc:43
 msgid ""
 "There is more to collections than lists. You can have instances of empty "
 "collections, some of which have literal support ([], {}, and ()). Thus there "
@@ -209,13 +209,13 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:42
+#: en/content/reference/lisps.adoc:44
 msgid ""
 "Coming from Scheme, _**nil**_ may map most closely to your notion of #f."
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:43
+#: en/content/reference/lisps.adoc:45
 msgid ""
 "A big difference in Clojure, is sequences. Sequences are not specific "
 "collections, esp. they are not necessarily concrete lists. When you ask an "
@@ -227,7 +227,7 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:44
+#: en/content/reference/lisps.adoc:46
 msgid ""
 "Some of the sequence functions correspond to functions from Scheme and CL "
 "that there manipulated only pairs/conses ('lists') and returned sentinel "
@@ -240,17 +240,16 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/lisps.adoc:45
+#: en/content/reference/lisps.adoc:47
 msgid ""
 "It helps to distinguish collections/data-structures and seqs/iteration. In "
 "both CL and Scheme they are conflated, in Clojure they are separate."
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/lisps.adoc:59
+#. type: Table
+#: en/content/reference/lisps.adoc:61
 #, no-wrap
 msgid ""
-"|===\n"
 "|   | Clojure | Common Lisp | Scheme | Java |\n"
 "| Has nil? | nil - means 'nothing' | nil - means false or empty list | - | null |\n"
 "| Has true? | true | - | #t | true (primitive) |\n"
@@ -262,5 +261,4 @@ msgid ""
 "| Host null: | nil | NA | NA | NA |\n"
 "| Host true: | true (boxed) | NA | NA | NA |\n"
 "| Host false: | false (boxed) | NA | NA | NA |\n"
-"|===\n"
 msgstr ""

--- a/i18n/pot/content/reference/macros/original.pot
+++ b/i18n/pot/content/reference/macros/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,33 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ==

--- a/i18n/pot/content/reference/metadata/original.pot
+++ b/i18n/pot/content/reference/metadata/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -51,33 +51,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Plain text
@@ -163,26 +136,44 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/metadata.adoc:39
+#: en/content/reference/metadata.adoc:38
 msgid ""
 "`^{:doc \"How obj works!\"} obj` - Sets the metadata of obj to the provided "
-"map.  ** Equivalent to `(with-meta obj {:doc \"How obj works!\"})`"
+"map."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/metadata.adoc:39
+msgid "Equivalent to `(with-meta obj {:doc \"How obj works!\"})`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/metadata.adoc:40
+msgid ""
+"`^:dynamic obj` - Sets the given keyword to true in the object's metadata."
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/metadata.adoc:41
-msgid ""
-"`^:dynamic obj` - Sets the given keyword to true in the object's metadata.  "
-"** Equivalent to `^{:dynamic true} obj`"
+msgid "Equivalent to `^{:dynamic true} obj`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/metadata.adoc:42
+msgid "`^String obj` - Sets the value of :tag key in the object's metadata."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/metadata.adoc:43
+msgid "Equivalent to `^{:tag java.lang.String} obj`"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/metadata.adoc:44
 msgid ""
-"`^String obj` - Sets the value of :tag key in the object's metadata.  ** "
-"Equivalent to `^{:tag java.lang.String} obj` ** Used to hint an objects type "
-"to the Clojure compiler. See <<java_interop#typehints,Java Interop: Type "
-"Hints>> for more information and a complete list of special type hints."
+"Used to hint an objects type to the Clojure compiler. See "
+"<<java_interop#typehints,Java Interop: Type Hints>> for more information and "
+"a complete list of special type hints."
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/multimethods/original.pot
+++ b/i18n/pot/content/reference/multimethods/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-06-01 09:26+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,32 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/spec.adoc:11 en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title =

--- a/i18n/pot/content/reference/namespaces/original.pot
+++ b/i18n/pot/content/reference/namespaces/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -46,33 +46,6 @@ msgstr ""
 msgid "Rich Hickey 2015-01-01"
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
-
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73
 #: en/content/reference/namespaces.adoc:24
@@ -96,7 +69,7 @@ msgstr ""
 
 #. type: Plain text
 #: en/content/reference/namespaces.adoc:1
-#: en/content/guides/reader_conditionals.adoc:87 en/content/guides/faq.adoc:126
+#: en/content/guides/reader_conditionals.adoc:87 en/content/guides/faq.adoc:133
 #: en/content/news/2011/07/22/introducing-clojurescript.adoc:28
 #, no-wrap
 msgid "Namespaces"

--- a/i18n/pot/content/reference/other_functions/original.pot
+++ b/i18n/pot/content/reference/other_functions/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,40 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ==
@@ -134,20 +100,17 @@ msgstr ""
 msgid "Creating functions"
 msgstr ""
 
-#. type: Plain text
-#: en/content/reference/other_functions.adoc:35
+#. type: Table
+#: en/content/reference/other_functions.adoc:34
+#, no-wrap
 msgid ""
-"|=== | Function | Example expression | Return value | | <<special_forms#fn#,"
-"fn>> | `(map (fn [x] (+ 2 x)) [1 2 3])` | `(3 4 5)` | | pass:[#()] <<reader#,"
-"reader>> macro | `(map #(+ 2 %) [1 2 3])` | `(3 4 5)` | | https://clojure."
-"github.io/clojure/clojure.core-api.html#clojure.core/partial[partial] | "
-"`(map (partial + 2) [1 2 3])` | `(3 4 5)` | | https://clojure.github.io/"
-"clojure/clojure.core-api.html#clojure.core/comp[comp] | `(map (comp - *) [2 "
-"4 6] [1 2 3])` | `(-2 -8 -18)` | | https://clojure.github.io/clojure/clojure."
-"core-api.html#clojure.core/complement[complement] | `(map (complement zero?) "
-"[3 2 1 0])` | `(true true true false)` | | https://clojure.github.io/clojure/"
-"clojure.core-api.html#clojure.core/constantly[constantly] | `(map "
-"(constantly 9) [1 2 3])` | `(9 9 9)` | |==="
+"| Function | Example expression | Return value |\n"
+"| <<special_forms#fn#,fn>> | `(map (fn [x] (+ 2 x)) [1 2 3])` | `(3 4 5)` |\n"
+"| pass:[#()] <<reader#,reader>> macro | `(map #(+ 2 %) [1 2 3])` | `(3 4 5)` |\n"
+"| https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/partial[partial] | `(map (partial + 2) [1 2 3])` | `(3 4 5)` |\n"
+"| https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/comp[comp] | `(map (comp - *) [2 4 6] [1 2 3])` | `(-2 -8 -18)` |\n"
+"| https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/complement[complement] | `(map (complement zero?) [3 2 1 0])` | `(true true true false)` |\n"
+"| https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/constantly[constantly] | `(map (constantly 9) [1 2 3])` | `(9 9 9)` |\n"
 msgstr ""
 
 #. type: Title ===

--- a/i18n/pot/content/reference/other_libraries/original.pot
+++ b/i18n/pot/content/reference/other_libraries/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,57 +17,33 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4
-#: en/content/reference/metadata.adoc:4 en/content/reference/evaluation.adoc:4
-#: en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4
+#: en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4
+#: en/content/reference/transients.adoc:4
 #: en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4
 #: en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4
+#: en/content/reference/transducers.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4
+#: en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4
 #: en/content/reference/data_structures.adoc:4
-#: en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4
-#: en/content/reference/lisps.adoc:4 en/content/reference/lazy.adoc:4
-#: en/content/reference/repl_and_main.adoc:4
-#: en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4
-#: en/content/reference/multimethods.adoc:4 en/content/search.adoc:4
-#: en/content/about/clojureclr.adoc:4
-#: en/content/about/functional_programming.adoc:4 en/content/about/lisp.adoc:4
-#: en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4
-#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4
-#: en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4
-#: en/content/privacy.adoc:4 en/content/community/swag.adoc:4
-#: en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
+#: en/content/reference/atoms.adoc:4 en/content/reference/repl_and_main.adoc:4
+#: en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4
 #: en/content/community/downloads_older.adoc:4
-#: en/content/community/libraries.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4
+#: en/content/404.adoc:4 en/content/privacy.adoc:4 en/content/search.adoc:4
+#: en/content/about/spec.adoc:4 en/content/about/concurrent_programming.adoc:4
+#: en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4
+#: en/content/about/features.adoc:4 en/content/about/rationale.adoc:4
+#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4
+#: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/sequences.adoc:15 en/content/reference/metadata.adoc:15
-#: en/content/reference/reader.adoc:13 en/content/reference/transients.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/datatypes.adoc:16 en/content/reference/agents.adoc:16
-#: en/content/reference/protocols.adoc:15 en/content/reference/reducers.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/transducers.adoc:15 en/content/reference/vars.adoc:16
-#: en/content/reference/namespaces.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/multimethods.adoc:15
-#: en/content/about/functional_programming.adoc:15
-#: en/content/about/dynamic.adoc:16 en/content/about/spec.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title =

--- a/i18n/pot/content/reference/protocols/original.pot
+++ b/i18n/pot/content/reference/protocols/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,33 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title =
@@ -114,27 +87,51 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/protocols.adoc:24
+msgid "Support the best parts of interfaces"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:25
+msgid "specification only, no implementation"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/protocols.adoc:26
+msgid "a single type can implement multiple protocols"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:27
+msgid "While avoiding some of the drawbacks"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:28
 msgid ""
-"Support the best parts of interfaces ** specification only, no "
-"implementation ** a single type can implement multiple protocols"
+"Which interfaces are implemented is a design-time choice of the type author, "
+"cannot be extended later (although interface injection might eventually "
+"address this)"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/protocols.adoc:29
 msgid ""
-"While avoiding some of the drawbacks ** Which interfaces are implemented is "
-"a design-time choice of the type author, cannot be extended later (although "
-"interface injection might eventually address this)  ** implementing an "
-"interface creates an isa/instanceof type relationship and hierarchy"
+"implementing an interface creates an isa/instanceof type relationship and "
+"hierarchy"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:30
+msgid ""
+"Avoid the 'expression problem' by allowing independent extension of the set "
+"of types, protocols, and implementations of protocols on types, by different "
+"parties"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/protocols.adoc:31
-msgid ""
-"Avoid the 'expression problem' by allowing independent extension of the set "
-"of types, protocols, and implementations of protocols on types, by different "
-"parties ** do so without wrappers/adapters"
+msgid "do so without wrappers/adapters"
 msgstr ""
 
 #. type: Plain text
@@ -185,10 +182,13 @@ msgid "Docs can be specified for the protocol and the functions"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/protocols.adoc:51
+msgid "The above yields a set of polymorphic functions and a protocol object"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/protocols.adoc:52
-msgid ""
-"The above yields a set of polymorphic functions and a protocol object ** all "
-"are namespace-qualified by the namespace enclosing the definition"
+msgid "all are namespace-qualified by the namespace enclosing the definition"
 msgstr ""
 
 #. type: Plain text
@@ -319,22 +319,44 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/protocols.adoc:104
+msgid "Function maps are maps of the keywordized method names to ordinary fns"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/protocols.adoc:105
 msgid ""
-"Function maps are maps of the keywordized method names to ordinary fns ** "
 "this facilitates easy reuse of existing fns and maps, for code reuse/mixins "
 "without derivation or composition"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/protocols.adoc:106
+msgid "You can implement a protocol on an interface"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:107
+msgid "this is primarily to facilitate interop with the host (e.g. Java)"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:108
+msgid "but opens the door to incidental multiple inheritance of implementation"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/protocols.adoc:109
+msgid ""
+"since a class can inherit from more than one interface, both of which "
+"implement the protocol"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/protocols.adoc:110
 msgid ""
-"You can implement a protocol on an interface ** this is primarily to "
-"facilitate interop with the host (e.g. Java)  ** but opens the door to "
-"incidental multiple inheritance of implementation *** since a class can "
-"inherit from more than one interface, both of which implement the protocol "
-"*** if one interface is derived from the other, the more derived is used, "
-"else which one is used is unspecified."
+"if one interface is derived from the other, the more derived is used, else "
+"which one is used is unspecified."
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/reader/original.pot
+++ b/i18n/pot/content/reference/reader/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:18+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,49 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/higher_order_functions.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11
-#: en/content/guides/repl/annex_troubleshooting.adoc:14
-#: en/content/guides/repl/navigating_namespaces.adoc:16
-#: en/content/guides/repl/introduction.adoc:14
-#: en/content/guides/repl/data_visualization_at_the_repl.adoc:16
-#: en/content/guides/repl/launching_a_basic_repl.adoc:16
-#: en/content/guides/repl/basic_usage.adoc:16
-#: en/content/guides/repl/enhancing_your_repl_workflow.adoc:16
-#: en/content/guides/faq.adoc:11 en/content/about/spec.adoc:16
-#: en/content/about/dynamic.adoc:16 en/content/about/rationale.adoc:13
-#: en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Plain text
 #: en/content/reference/transducers.adoc:39
@@ -179,17 +136,31 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/reader.adoc:38
+#: en/content/reference/reader.adoc:35
+msgid "Numbers - generally represented as per Java"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:36
 msgid ""
-"Numbers - generally represented as per Java ** Integers can be indefinitely "
-"long and will be read as Longs when in range and clojure.lang.BigInts "
-"otherwise. Integers with an N suffix are always read as BigInts. When "
-"possible, they can be specified in any base with radix from 2 to 36 (see "
-"http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong(java."
-"lang.String,%20int)[Long.parseLong()]); for example `2r101010`, `8r52`, "
-"`36r16`, and `42` are all the same Long.  ** Floating point numbers are read "
-"as Doubles; with M suffix they are read as BigDecimals.  ** Ratios are "
-"supported, e.g. `22/7`."
+"Integers can be indefinitely long and will be read as Longs when in range "
+"and clojure.lang.BigInts otherwise. Integers with an N suffix are always "
+"read as BigInts. When possible, they can be specified in any base with radix "
+"from 2 to 36 (see http://docs.oracle.com/javase/7/docs/api/java/lang/Long."
+"html#parseLong(java.lang.String,%20int)[Long.parseLong()]); for example "
+"`2r101010`, `8r52`, `36r16`, and `42` are all the same Long."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:37
+msgid ""
+"Floating point numbers are read as Doubles; with M suffix they are read as "
+"BigDecimals."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:38
+msgid "Ratios are supported, e.g. `22/7`."
 msgstr ""
 
 #. type: Plain text
@@ -213,15 +184,43 @@ msgid "Booleans - `true` and `false`"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/reader.adoc:42
+msgid "Keywords - Keywords are like symbols, except:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:43
+msgid "They can and must begin with a colon, e.g. :fred."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:44
+msgid "They cannot contain '.' or name classes."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:45
+msgid "Like symbols, they can contain a namespace, `:person/name`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:46
+msgid ""
+"A keyword that begins with two colons is auto-resolved in the current "
+"namespace to a qualified keyword:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:47
+msgid ""
+"If the keyword is unqualified, the namespace will be the current namespace. "
+"In `user`, `::rect` is read as `:user/rect`."
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/reader.adoc:48
 msgid ""
-"Keywords - Keywords are like symbols, except: ** They can and must begin "
-"with a colon, e.g. :fred.  ** They cannot contain '.' or name classes.  ** "
-"Like symbols, they can contain a namespace, `:person/name` ** A keyword that "
-"begins with two colons is auto-resolved in the current namespace to a "
-"qualified keyword: *** If the keyword is unqualified, the namespace will be "
-"the current namespace. In `user`, `::rect` is read as `:user/rect`.  *** If "
-"the keyword is qualified, the namespace will be resolved using aliases in "
+"If the keyword is qualified, the namespace will be resolved using aliases in "
 "the current namespace. In a namespace where `x` is aliased to `example`, `::"
 "x/foo` resolves to `:example/foo`."
 msgstr ""
@@ -303,21 +302,44 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/reader.adoc:76
+#: en/content/reference/reader.adoc:73
+msgid "Keys"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:74
 msgid ""
-"Keys ** Keys that are keywords or symbols without a namespace are read with "
-"the default namespace.  ** Keys that are keywords or symbols with a "
-"namespace are not affected *except* for the special namespace `_`, which is "
-"removed during read. This allows for the specification of keywords or "
-"symbols without namespaces as keys in a map literal with namespace syntax.  "
-"** Keys that are not symbols or keywords are not affected."
+"Keys that are keywords or symbols without a namespace are read with the "
+"default namespace."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:75
+msgid ""
+"Keys that are keywords or symbols with a namespace are not affected *except* "
+"for the special namespace `_`, which is removed during read. This allows for "
+"the specification of keywords or symbols without namespaces as keys in a map "
+"literal with namespace syntax."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:76
+msgid "Keys that are not symbols or keywords are not affected."
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:77
+msgid "Values"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reader.adoc:78
+msgid "Values are not affected."
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/reader.adoc:79
-msgid ""
-"Values ** Values are not affected.  ** Nested map literal keys are not "
-"affected."
+msgid "Nested map literal keys are not affected."
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/reducers/original.pot
+++ b/i18n/pot/content/reference/reducers/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2017-03-09 15:46+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,57 +17,33 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #. type: Plain text
-#: en/content/reference/atoms.adoc:4 en/content/reference/sequences.adoc:4
-#: en/content/reference/metadata.adoc:4 en/content/reference/evaluation.adoc:4
-#: en/content/reference/transients.adoc:4 en/content/reference/macros.adoc:4
-#: en/content/reference/documentation.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/metadata.adoc:4 en/content/reference/protocols.adoc:4
+#: en/content/reference/sequences.adoc:4
+#: en/content/reference/multimethods.adoc:4 en/content/reference/libs.adoc:4
+#: en/content/reference/transients.adoc:4
 #: en/content/reference/compilation.adoc:4
-#: en/content/reference/other_functions.adoc:4
 #: en/content/reference/other_libraries.adoc:4
+#: en/content/reference/documentation.adoc:4 en/content/reference/macros.adoc:4
+#: en/content/reference/transducers.adoc:4 en/content/reference/refs.adoc:4
+#: en/content/reference/lazy.adoc:4 en/content/reference/namespaces.adoc:4
+#: en/content/reference/lisps.adoc:4 en/content/reference/evaluation.adoc:4
+#: en/content/reference/other_functions.adoc:4
+#: en/content/reference/reducers.adoc:4
 #: en/content/reference/data_structures.adoc:4
-#: en/content/reference/datatypes.adoc:4 en/content/reference/agents.adoc:4
-#: en/content/reference/protocols.adoc:4 en/content/reference/reducers.adoc:4
-#: en/content/reference/lisps.adoc:4 en/content/reference/lazy.adoc:4
-#: en/content/reference/repl_and_main.adoc:4
-#: en/content/reference/transducers.adoc:4
-#: en/content/reference/namespaces.adoc:4 en/content/reference/libs.adoc:4
-#: en/content/reference/multimethods.adoc:4 en/content/search.adoc:4
-#: en/content/about/clojureclr.adoc:4
-#: en/content/about/functional_programming.adoc:4 en/content/about/lisp.adoc:4
-#: en/content/about/features.adoc:4 en/content/about/dynamic.adoc:4
-#: en/content/about/concurrent_programming.adoc:4 en/content/about/spec.adoc:4
-#: en/content/about/rationale.adoc:4 en/content/about/state.adoc:4
-#: en/content/about/clojurescript.adoc:4 en/content/about/jvm_hosted.adoc:4
-#: en/content/about/runtime_polymorphism.adoc:4 en/content/404.adoc:4
-#: en/content/privacy.adoc:4 en/content/community/swag.adoc:4
-#: en/content/community/downloads.adoc:4 en/content/community/license.adoc:4
+#: en/content/reference/atoms.adoc:4 en/content/reference/repl_and_main.adoc:4
+#: en/content/reference/agents.adoc:4 en/content/reference/datatypes.adoc:4
+#: en/content/community/libraries.adoc:4 en/content/community/license.adoc:4
 #: en/content/community/downloads_older.adoc:4
-#: en/content/community/libraries.adoc:4
+#: en/content/community/downloads.adoc:4 en/content/community/swag.adoc:4
+#: en/content/404.adoc:4 en/content/privacy.adoc:4 en/content/search.adoc:4
+#: en/content/about/spec.adoc:4 en/content/about/concurrent_programming.adoc:4
+#: en/content/about/lisp.adoc:4 en/content/about/jvm_hosted.adoc:4
+#: en/content/about/runtime_polymorphism.adoc:4 en/content/about/dynamic.adoc:4
+#: en/content/about/features.adoc:4 en/content/about/rationale.adoc:4
+#: en/content/about/state.adoc:4 en/content/about/clojurescript.adoc:4
+#: en/content/about/functional_programming.adoc:4
+#: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/sequences.adoc:15 en/content/reference/metadata.adoc:15
-#: en/content/reference/reader.adoc:13 en/content/reference/transients.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/refs.adoc:15
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/datatypes.adoc:16 en/content/reference/agents.adoc:16
-#: en/content/reference/protocols.adoc:15 en/content/reference/reducers.adoc:15
-#: en/content/reference/lazy.adoc:12 en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/transducers.adoc:15 en/content/reference/vars.adoc:16
-#: en/content/reference/namespaces.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/multimethods.adoc:15
-#: en/content/about/functional_programming.adoc:15
-#: en/content/about/dynamic.adoc:16 en/content/about/spec.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/guides/reader_conditionals.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title =
@@ -168,11 +144,15 @@ msgid "Map colls are reduced with reduce-kv"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/reducers.adoc:41
+#: en/content/reference/reducers.adoc:40
 msgid ""
 "When init is not provided, f is invoked with no arguments to produce an "
-"identity value ** _Note: f may be invoked multiple times to provide the "
-"identity value_"
+"identity value"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/reducers.adoc:41
+msgid "_Note: f may be invoked multiple times to provide the identity value_"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/refs/original.pot
+++ b/i18n/pot/content/reference/refs/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,33 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ==

--- a/i18n/pot/content/reference/repl_and_main/original.pot
+++ b/i18n/pot/content/reference/repl_and_main/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,33 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ==
@@ -132,28 +105,80 @@ msgid "With no options or args, runs an interactive Read-Eval-Print Loop"
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/repl_and_main.adoc:27
+msgid "init options:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:28
+msgid "-i, --init path Load a file or resource"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/repl_and_main.adoc:29
-msgid ""
-"init options: ** -i, --init path Load a file or resource ** -e, --eval "
-"string Evaluate expressions in string; print non-nil values"
+msgid "-e, --eval string Evaluate expressions in string; print non-nil values"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:30
+msgid "main options:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:31
+msgid "-r, --repl Run a repl"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:32
+msgid "path Run a script from a file or resource"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:33
+msgid "- Run a script from standard input"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:34
+msgid "-m, --main A namespace to find a -main function for execution"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/repl_and_main.adoc:35
+msgid "-h, -?, --help Print this help message and exit"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:36
+msgid "operation:"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:37
+msgid "Establishes thread-local bindings for commonly set!-able vars"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:38
+msgid "Enters the user namespace"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:39
 msgid ""
-"main options: ** -r, --repl Run a repl ** path Run a script from a file or "
-"resource ** - Run a script from standard input ** -m, --main A namespace to "
-"find a -main function for execution ** -h, -?, --help Print this help "
-"message and exit"
+"Binds \\*command-line-args* to a seq of strings containing command line args "
+"that appear after any main option"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/repl_and_main.adoc:40
+msgid "Runs all init options in order"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/repl_and_main.adoc:41
-msgid ""
-"operation: ** Establishes thread-local bindings for commonly set!-able vars "
-"** Enters the user namespace ** Binds \\*command-line-args* to a seq of "
-"strings containing command line args that appear after any main option ** "
-"Runs all init options in order ** Runs a repl or script if requested"
+msgid "Runs a repl or script if requested"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/sequences/original.pot
+++ b/i18n/pot/content/reference/sequences/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,33 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ====

--- a/i18n/pot/content/reference/special_forms/original.pot
+++ b/i18n/pot/content/reference/special_forms/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,34 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title =
 #: en/content/reference/special_forms.adoc:1
@@ -889,19 +861,37 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/special_forms.adoc:338
+#: en/content/reference/special_forms.adoc:336
 msgid ""
 "`:__ns__/keys` - _ns_ specifies the default namespace for the key to look up "
-"in the input ** keys elements should not specify a namespace ** keys "
-"elements also define new local symbols, as with `:keys`"
+"in the input"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/special_forms.adoc:337
+msgid "keys elements should not specify a namespace"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/special_forms.adoc:338
+msgid "keys elements also define new local symbols, as with `:keys`"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/special_forms.adoc:339
+msgid ""
+"`:__ns__/syms` - _ns_ specifies the default namespace for the symbol to look "
+"up in the input"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/special_forms.adoc:340
+msgid "syms elements should not specify a namespace"
 msgstr ""
 
 #. type: Plain text
 #: en/content/reference/special_forms.adoc:341
-msgid ""
-"`:__ns__/syms` - _ns_ specifies the default namespace for the symbol to look "
-"up in the input ** syms elements should not specify a namespace ** syms "
-"elements also define new local symbols, as with `:syms`"
+msgid "syms elements also define new local symbols, as with `:syms`"
 msgstr ""
 
 #. type: delimited block -

--- a/i18n/pot/content/reference/transducers/original.pot
+++ b/i18n/pot/content/reference/transducers/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-03-31 17:24+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,34 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title ==

--- a/i18n/pot/content/reference/transients/original.pot
+++ b/i18n/pot/content/reference/transients/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-04-02 07:15+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,40 +44,6 @@ msgstr ""
 #: en/content/about/functional_programming.adoc:4
 #: en/content/about/clojureclr.adoc:4
 msgid "Rich Hickey 2015-01-01"
-msgstr ""
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/deps_and_cli.adoc:13
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/deps_and_cli.adoc:11
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/getting_started.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/learn/hashed_colls.adoc:16
-#: en/content/guides/learn/syntax.adoc:14 en/content/guides/learn/flow.adoc:14
-#: en/content/guides/learn/sequential_colls.adoc:16
-#: en/content/guides/learn/functions.adoc:16
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
 msgstr ""
 
 #. type: Title =
@@ -345,11 +311,23 @@ msgid ""
 msgstr ""
 
 #. type: Plain text
+#: en/content/reference/transients.adoc:86
+msgid "Same code structure as functional version"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/transients.adoc:87
+msgid "Capture return value, use for next call"
+msgstr ""
+
+#. type: Plain text
+#: en/content/reference/transients.adoc:88
+msgid "Don't bash in place"
+msgstr ""
+
+#. type: Plain text
 #: en/content/reference/transients.adoc:89
-msgid ""
-"Same code structure as functional version ** Capture return value, use for "
-"next call ** Don't bash in place ** Not persistent, so you can't hang onto "
-"interim values or alias"
+msgid "Not persistent, so you can't hang onto interim values or alias"
 msgstr ""
 
 #. type: Plain text

--- a/i18n/pot/content/reference/vars/original.pot
+++ b/i18n/pot/content/reference/vars/original.pot
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: clojure-site-ja 0.0.1\n"
-"POT-Creation-Date: 2018-02-07 07:23+0900\n"
+"POT-Creation-Date: 2019-06-12 00:05+0900\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,33 +15,6 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-
-#. type: Plain text
-#: en/content/reference/metadata.adoc:15 en/content/reference/protocols.adoc:15
-#: en/content/reference/sequences.adoc:15
-#: en/content/reference/multimethods.adoc:15 en/content/reference/libs.adoc:16
-#: en/content/reference/transients.adoc:16
-#: en/content/reference/compilation.adoc:16
-#: en/content/reference/other_libraries.adoc:16
-#: en/content/reference/macros.adoc:15 en/content/reference/transducers.adoc:15
-#: en/content/reference/refs.adoc:15 en/content/reference/lazy.adoc:12
-#: en/content/reference/reader.adoc:13
-#: en/content/reference/special_forms.adoc:15
-#: en/content/reference/namespaces.adoc:15
-#: en/content/reference/java_interop.adoc:15
-#: en/content/reference/other_functions.adoc:17
-#: en/content/reference/vars.adoc:16 en/content/reference/reducers.adoc:15
-#: en/content/reference/data_structures.adoc:16
-#: en/content/reference/repl_and_main.adoc:16
-#: en/content/reference/agents.adoc:16 en/content/reference/datatypes.adoc:16
-#: en/content/guides/weird_characters.adoc:10 en/content/guides/spec.adoc:11
-#: en/content/guides/reader_conditionals.adoc:10
-#: en/content/guides/destructuring.adoc:11 en/content/guides/faq.adoc:11
-#: en/content/about/spec.adoc:16 en/content/about/dynamic.adoc:16
-#: en/content/about/rationale.adoc:13 en/content/about/state.adoc:16
-#: en/content/about/functional_programming.adoc:15
-msgid "toc::[]"
-msgstr ""
 
 #. type: Title ==
 #: en/content/reference/libs.adoc:64 en/content/reference/refs.adoc:73
@@ -83,7 +56,7 @@ msgid "Vars and the Global Environment"
 msgstr ""
 
 #. type: Plain text
-#: en/content/reference/vars.adoc:4 en/content/guides/getting_started.adoc:4
+#: en/content/reference/vars.adoc:4
 msgid "Rich Hickey 2016-01-14"
 msgstr ""
 

--- a/site/jbake.properties
+++ b/site/jbake.properties
@@ -19,7 +19,7 @@ outfilesuffix=
 # section specific templates
 template.reference.file=reference.ftl
 template.about.file=about.ftl
-# template.guides.file=guides.ftl
+template.guides.file=guides.ftl
 # template.community.file=community.ftl
 # template.notfound.file=404.ftl
 # template.news.file=news.ftl

--- a/site/templates/guides.ftl
+++ b/site/templates/guides.ftl
@@ -1,0 +1,15 @@
+<#include "header.ftl">
+
+<#include "menu.ftl">
+
+<div class="page-header">
+  <h1><#escape x as x?xml>${content.title}</#escape></h1>
+</div>
+
+<p><em></em></p>
+
+<p>${content.body}</p>
+
+<hr />
+
+<#include "footer.ftl">

--- a/site/templates/menu.ftl
+++ b/site/templates/menu.ftl
@@ -15,9 +15,9 @@
             <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>about/rationale.html">概要</a></li>
             <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>reference/documentation">リファレンス</a></li>
             <!-- <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>api/api.html">API</a></li>
-              <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/downloads.html">リリース</a></li>
+              <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/downloads.html">リリース</a></li> -->
               <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>guides/guides.html">ガイド</a></li>
-              <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/resources.html">コミュニティ</a></li>
+            <!-- <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/resources.html">コミュニティ</a></li>
               <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>news/news.html">ニュース</a></li>
               <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Dropdown <b class="caret"></b></a>


### PR DESCRIPTION
#44 の対応に倣ってGUIDESページを表示可能にするとともに、 `make build` で生じたfuzzyとuntranslatedなエントリを修正しました。

現状、 `guides/learn`, `guides/repl` 配下のページは生成されないようです😇